### PR TITLE
Optimize Dockerfile for Go installation and pip commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,10 @@ USER root
 RUN yum update -y && \
     rm -rf /var/cache/yum
 
-RUN wget https://go.dev/dl/go1.25.1.linux-amd64.tar.gz
-RUN tar -C /usr/local -xzf go1.25.1.linux-amd64.tar.gz
+RUN wget https://go.dev/dl/go1.25.1.linux-amd64.tar.gz && \
+    tar -C /usr/local -xzf go1.25.1.linux-amd64.tar.gz && \
+    rm -f go1.25.1.linux-amd64.tar.gz
 ENV PATH=$PATH:/usr/local/go/bin
 
-RUN pip install robotframework-jsonlibrary PyJWT  oscar-python==1.3.3
+RUN pip install --no-cache-dir robotframework-jsonlibrary PyJWT
+RUN pip install --no-cache-dir oscar-python==1.3.3


### PR DESCRIPTION
Combine wget and tar commands for Go installation and remove the downloaded tar.gz file. Update pip install commands to use --no-cache-dir.