### PR TITLE
update isolation test

### DIFF
--- a/tests/api/isolation.robot
+++ b/tests/api/isolation.robot
@@ -4,14 +4,14 @@ Library           Process
 Library           RequestsLibrary
 Resource          ${CURDIR}/../../${AUTHENTICATION_PROCESS} 
 Resource          ${CURDIR}/../../resources/files.resource
+Resource          ${CURDIR}/../../resources/service.resource
 
-Suite Setup       Checks Valids OIDC Token
+Suite Setup       Run Keywords    Checks Valids OIDC Token    AND    Assign Random Service Name
 Suite Teardown    Clean Test Artifacts    True    ${DATA_DIR}/service_file.json
 
 
 *** Variables ***
-${service_name}     robot-test-cowsay
-${bucket_name}      robot-test-cowsay
+${SERVICE_BASE}     robot-test-cowsay
 
 *** Test Cases ***
 
@@ -208,6 +208,13 @@ Prepare Service File
     ...    jq '.message' \"$INPUT_FILE_PATH\" -r | /usr/games/cowsay\nelse\n
     ...    cat \"$INPUT_FILE_PATH\" | /usr/games/cowsay\nfi\n\
     Set To Dictionary    ${modified_content}    script=${script_value}
+    Set To Dictionary    ${modified_content}    name=${SERVICE_NAME}
+    ${input_entries}=    Get From Dictionary    ${modified_content}    input
+    ${first_input}=    Get From List    ${input_entries}    0
+    Set To Dictionary    ${first_input}    path=${SERVICE_NAME}/input
+    ${output_entries}=    Get From Dictionary    ${modified_content}    output
+    ${first_output}=    Get From List    ${output_entries}    0
+    Set To Dictionary    ${first_output}    path=${SERVICE_NAME}/output
     ${service_content_json}=    Evaluate    json.dumps(${modified_content})    json
     Create File    ${DATA_DIR}/service_file.json    ${service_content_json}
 


### PR DESCRIPTION
This pull request updates the isolation tests for the API to improve service name handling and test setup. The main changes focus on dynamically assigning service names and ensuring that service file paths are correctly set based on the assigned name.

**Test setup improvements:**
* The test suite now assigns a random service name during setup by adding `Assign Random Service Name` to the `Suite Setup` and loading the `service.resource` file. This allows tests to avoid hardcoded service names and reduces the risk of collisions.

**Service file preparation enhancements:**
* The `Prepare Service File` keyword now sets the service name dynamically in the service file content and updates the input and output paths to use the assigned service name, ensuring consistency and correctness in test artifacts.