### PR TITLE
Reduce cowsay test service memory from 1Gi to 128Mi

### DIFF
--- a/data/00-cowsay.yaml
+++ b/data/00-cowsay.yaml
@@ -4,7 +4,7 @@ functions:
       name: robot-test-cowsay
       cpu: '1.0'
       vo: <VO>
-      memory: 1Gi
+      memory: 128Mi
       image: ghcr.io/grycap/cowsay
       script: 00-cowsay-script.sh
       input:


### PR DESCRIPTION
## Summary

This PR reduces the memory requested by the shared cowsay test service definition from `1Gi` to `128Mi`.

## Why

The `service-lifecycle.robot` suite creates the cowsay service from the shared `data/00-cowsay.yaml` definition, and the current `1Gi` request is unnecessarily high for this workload. A `128Mi` request is sufficient for the cowsay test service and makes the suite lighter to run in constrained environments.

## Changes

- update `data/00-cowsay.yaml`
- change `memory: 1Gi` to `memory: 128Mi`

## Validation

- reviewed the shared cowsay service definition used by the lifecycle tests
- confirmed the change is limited to the common test service YAML
