### PR TITLE
Add OSCAR scalability test suite and experiment viewer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ variables/.env-*
 *.txt
 *.xml
 *.html
+!tests/scalability/viewer/index.html
 browser
 True
 robot_results
+__pycache__/
+*.py[cod]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,4 @@ RUN wget https://go.dev/dl/go1.25.1.linux-amd64.tar.gz
 RUN tar -C /usr/local -xzf go1.25.1.linux-amd64.tar.gz
 ENV PATH=$PATH:/usr/local/go/bin
 
-RUN pip install robotframework-jsonlibrary PyJWT  oscar-python==1.3.3
+RUN pip install robotframework-jsonlibrary PyJWT locust oscar-python==1.3.3

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Targets that should not be treated as positional arguments.
-RESERVED_GOALS := test help list
+RESERVED_GOALS := test help list clean-results clean-scalability-results
 .DEFAULT_GOAL := help
 
 OTHER_GOALS := $(filter-out $(RESERVED_GOALS),$(MAKECMDGOALS))
@@ -41,6 +41,7 @@ SUITE_LIST := $(shell find tests -type f -name '*.robot' | sort)
 
 ROBOT ?= robot
 ROBOT_SUITE ?= tests/api/service-lifecycle.robot
+ROBOT_ARGS ?=
 ROBOT_OUTPUT_DIR ?= robot_results
 
 AUTH_EXAMPLE := $(firstword $(AUTH_OPTIONS))
@@ -62,13 +63,23 @@ ifeq ($(filter test,$(MAKECMDGOALS)),test)
   endif
 endif
 
-.PHONY: test help list
+.PHONY: test help list clean-results clean-scalability-results
 
 test:
 	@echo "Auth config: $(AUTH_FILE)"
 	@echo "Cluster config: $(CLUSTER_FILE)"
+	@echo "Robot suite: $(ROBOT_SUITE)"
+	@echo "Robot args: $(ROBOT_ARGS)"
 ifneq ($(ROBOT_SUITE),all)
-	$(ROBOT) -V $(AUTH_FILE) -V $(CLUSTER_FILE) -d $(ROBOT_OUTPUT_DIR) $(ROBOT_SUITE)
+	OSCAR_TEST_AUTH_GOAL="$(AUTH_GOAL)" \
+	OSCAR_TEST_CLUSTER_GOAL="$(CLUSTER_GOAL)" \
+	OSCAR_TEST_AUTH_FILE="$(AUTH_FILE)" \
+	OSCAR_TEST_CLUSTER_FILE="$(CLUSTER_FILE)" \
+	OSCAR_TEST_ROBOT="$(ROBOT)" \
+	OSCAR_TEST_ROBOT_SUITE="$(ROBOT_SUITE)" \
+	OSCAR_TEST_ROBOT_ARGS="$(ROBOT_ARGS)" \
+	OSCAR_TEST_ROBOT_OUTPUT_DIR="$(ROBOT_OUTPUT_DIR)" \
+	$(ROBOT) -V $(AUTH_FILE) -V $(CLUSTER_FILE) $(ROBOT_ARGS) -d $(ROBOT_OUTPUT_DIR) $(ROBOT_SUITE)
 else
 	@echo "Running all Robot test suites found under tests/."
 	@if [ -z "$(strip $(SUITE_LIST))" ]; then \
@@ -83,13 +94,39 @@ else
 	  out_dir="$(ROBOT_OUTPUT_DIR)/$${safe_dir}"; \
 	  echo "-> $$suite (output: $$out_dir)"; \
 	  mkdir -p "$$out_dir"; \
-	  $(ROBOT) -V $(AUTH_FILE) -V $(CLUSTER_FILE) -d "$$out_dir" "$$suite"; \
+	  OSCAR_TEST_AUTH_GOAL="$(AUTH_GOAL)" \
+	  OSCAR_TEST_CLUSTER_GOAL="$(CLUSTER_GOAL)" \
+	  OSCAR_TEST_AUTH_FILE="$(AUTH_FILE)" \
+	  OSCAR_TEST_CLUSTER_FILE="$(CLUSTER_FILE)" \
+	  OSCAR_TEST_ROBOT="$(ROBOT)" \
+	  OSCAR_TEST_ROBOT_SUITE="$$suite" \
+	  OSCAR_TEST_ROBOT_ARGS="$(ROBOT_ARGS)" \
+	  OSCAR_TEST_ROBOT_OUTPUT_DIR="$$out_dir" \
+	  $(ROBOT) -V $(AUTH_FILE) -V $(CLUSTER_FILE) $(ROBOT_ARGS) -d "$$out_dir" "$$suite"; \
 	done
 endif
+
+clean-results:
+	@if [ -z "$(strip $(ROBOT_OUTPUT_DIR))" ] || [ "$(ROBOT_OUTPUT_DIR)" = "/" ]; then \
+	  echo "Refusing to remove unsafe ROBOT_OUTPUT_DIR='$(ROBOT_OUTPUT_DIR)'"; \
+	  exit 1; \
+	fi
+	@echo "Removing Robot results: $(ROBOT_OUTPUT_DIR)"
+	rm -rf "$(ROBOT_OUTPUT_DIR)"
+
+clean-scalability-results:
+	@if [ -z "$(strip $(ROBOT_OUTPUT_DIR))" ] || [ "$(ROBOT_OUTPUT_DIR)" = "/" ]; then \
+	  echo "Refusing to remove unsafe ROBOT_OUTPUT_DIR='$(ROBOT_OUTPUT_DIR)'"; \
+	  exit 1; \
+	fi
+	@echo "Removing scalability results: $(ROBOT_OUTPUT_DIR)/scalability"
+	rm -rf "$(ROBOT_OUTPUT_DIR)/scalability"
 
 help:
 	@echo "Usage:"
 	@echo "  make test auth-<auth config> <cluster config>"
+	@echo "  make clean-results"
+	@echo "  make clean-scalability-results"
 	@echo ""
 	@echo "Available auth configurations:"
 	@$(if $(AUTH_OPTIONS),printf '  %s\n' $(AUTH_OPTIONS),echo '  (none found)')
@@ -110,7 +147,12 @@ endif
 	@echo "Optional overrides:"
 	@echo "  ROBOT=<robot command> (default: $(ROBOT))"
 	@echo "  ROBOT_SUITE=<suite path> (default: $(ROBOT_SUITE))"
+	@echo "  ROBOT_ARGS=<extra Robot args, e.g. -v NAME:value>"
 	@echo "  ROBOT_OUTPUT_DIR=<dir> (default: $(ROBOT_OUTPUT_DIR))"
+	@echo ""
+	@echo "Cleanup:"
+	@echo "  make clean-results              Remove $(ROBOT_OUTPUT_DIR)"
+	@echo "  make clean-scalability-results  Remove $(ROBOT_OUTPUT_DIR)/scalability"
 
 list:
 	@echo "Available auth configurations:"

--- a/README.md
+++ b/README.md
@@ -101,10 +101,7 @@ If you are testing an OSCAR deployment in localhost, you can override SSL verifi
 robot -V variables/.env-localhost.yaml -v SSL_VERIFY:False -v LOCAL_TESTING:True -d robot_results tests/api/service-lifecycle.robot
 ```
 
-You can run stress tests with [Locust](https://locust.io) via:
-```sh
-robot -V variables/.env-cluster.yaml -d robot_results tests/locust/stress-locust.robot
-````
+Scalability and Locust-based stress tests are documented in [`tests/scalability/README.md`](tests/scalability/README.md). That guide covers how the tests are executed, how quota-aware load plans are computed, which artifacts are produced, and how to open the D3-based static viewer for one or more experiments.
 
 ### 🧰 Using the Makefile Helper
 
@@ -140,13 +137,16 @@ The repository ships with a `Makefile` that auto-discovers the available credent
   make test auth-<auth-config> <cluster-config> ROBOT_SUITE=all
   ```
   Each suite is executed separately with results stored under `robot_results/<suite-name>/`.
-
-You can see the results of the stress test with:
-```sh
-open "$(ls -t robot_results/locust/*.html | head -1)"    # macOS
-# or
-xdg-open "$(ls -t robot_results/locust/*.html | head -1)" # Linux
-```
+- Remove previous scalability artifacts:
+  ```sh
+  make clean-scalability-results
+  ```
+  This deletes `robot_results/scalability`, including experiment JSON files, Locust CSV/HTML reports, and the generated viewer data.
+- Remove all Robot Framework results:
+  ```sh
+  make clean-results
+  ```
+  This deletes the full `robot_results` directory. Both cleanup targets honor `ROBOT_OUTPUT_DIR` if you override it.
 
 ### 🧪 Local kind Deployment Workflow
 

--- a/data/simple-test-input.payload
+++ b/data/simple-test-input.payload
@@ -1,0 +1,1 @@
+The quick brown fox jumped over the lazy dog

--- a/data/simple-test-script.sh
+++ b/data/simple-test-script.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+FILE_NAME=$(basename "$INPUT_FILE_PATH" | cut -d. -f1)
+OUTPUT_FILE="$TMP_OUTPUT_DIR/$FILE_NAME-out.txt"
+
+cat "$INPUT_FILE_PATH" > "$OUTPUT_FILE"
+
+WORD_COUNT=$(wc -w < "$INPUT_FILE_PATH")
+CHAR_COUNT=$(wc -m < "$INPUT_FILE_PATH")
+
+echo "File $FILE_NAME was processed. Output saved in: $OUTPUT_FILE"
+echo "Analysis:" >> "$OUTPUT_FILE"
+echo "Words: $WORD_COUNT" >> "$OUTPUT_FILE"
+echo "Characters: $CHAR_COUNT" >> "$OUTPUT_FILE"

--- a/data/simple-test.yaml
+++ b/data/simple-test.yaml
@@ -1,0 +1,16 @@
+functions:
+  oscar:
+  - oscar-cluster:
+      name: simple-test
+      memory: 256Mi
+      cpu: '1.0'
+      image: ubuntu
+      script: simple-test-script.sh
+      allowed_users: []
+      log_level: CRITICAL
+      input:
+      - storage_provider: minio.default
+        path: simple-test/input
+      output:
+      - storage_provider: minio.default
+        path: simple-test/output

--- a/tests/scalability/README.md
+++ b/tests/scalability/README.md
@@ -1,0 +1,453 @@
+# OSCAR Scalability Tests
+
+This directory contains the Locust-based scalability and API stress suites for OSCAR.
+
+```text
+tests/scalability/
+  scalability.robot          # Service invocation scalability experiment
+  stress-api.robot           # OSCAR Manager API stress suite
+  src/                       # Python helpers used by the Robot suites
+  viewer/                    # Static D3 viewer template
+```
+
+The main scalability suite creates a temporary `simple-test-*` service and measures both synchronous and asynchronous invocations under increasing load. Each run produces a portable experiment JSON file and publishes a static D3 viewer that can display one or more experiments.
+
+## Quick Start
+
+Run a full scalability experiment with the Makefile helper:
+
+```sh
+make test auth-keycloak-gmolto cluster-localhost \
+  ROBOT_SUITE=tests/scalability/scalability.robot \
+  ROBOT_ARGS="-v SCALABILITY_USERS:1,2,4 -v SCALABILITY_RUN_TIME:30s -v SCALABILITY_SPAWN_RATE:1 -v SCALABILITY_ASYNC_SETTLE_TIME:60s"
+```
+
+Open the static viewer:
+
+```sh
+open tests/scalability/viewer/index.html
+```
+
+The suite also prints the exact experiment artifact and viewer paths at the end of the run:
+
+```text
+OSCAR scalability experiment artifact: .../robot_results/scalability/experiments/simple-test-xxxx/experiment.json
+OSCAR scalability viewer: .../tests/scalability/viewer/index.html
+OSCAR scalability published viewer copy: .../robot_results/scalability/viewer/index.html
+```
+
+## What The Test Does
+
+The scalability suite performs these steps:
+
+1. Configures the selected authentication mode for OSCAR Manager operations: OIDC bearer token for the test user, or Basic auth for the OSCAR `oscar` user.
+2. Creates a dedicated experiment directory under `robot_results/scalability/experiments/<experiment-id>/`.
+3. Records the OSCAR cluster endpoint configured by the selected cluster variables.
+4. Captures the initial cluster resource snapshot from `/system/status`.
+5. Creates a temporary `simple-test-*` OSCAR service with the selected manager authentication mode.
+6. Configures invocation authentication for `POST /run/{service}` and `POST /job/{service}`.
+7. Computes a load plan, optionally using the user's quota from `/system/quotas/user`.
+8. Measures isolated first-ready and warm baseline invocations before Locust starts.
+9. Writes non-secret run configuration metadata for reproducibility.
+10. Runs one Locust step per configured user count for synchronous invocations through `POST /run/{service}`.
+11. Submits asynchronous warm-up jobs before the measured async load steps.
+12. Runs one Locust step per configured user count for asynchronous submissions through `POST /job/{service}`.
+13. Waits `SCALABILITY_ASYNC_SETTLE_TIME` after each async step.
+14. Queries OSCAR Manager job data from `GET /system/logs/{service}` using the manager authentication mode.
+15. Writes per-step summaries, a normalized experiment JSON, and a D3 static viewer.
+16. Deletes the temporary service and jobs unless cleanup variables are disabled.
+
+Direct HTTP invocation payloads are base64-encoded by default in the Locust client, matching the format used by `oscar-cli service run --text-input`.
+
+Manager API calls and service invocations can use different credentials. In `SCALABILITY_AUTH_MODE:user`, the OIDC user bearer token is used for both manager API calls and invocations. In `SCALABILITY_AUTH_MODE:oscar`, the suite uses `BASIC_USER` from the cluster file for manager API calls, then reads the generated service token from `GET /system/services/{service}` and uses that token for `POST /run/{service}` and `POST /job/{service}`. Tokens and credentials are never written to the experiment artifacts.
+
+## Invocation Modes
+
+The suite measures two different behaviors:
+
+| Mode | Endpoint | What It Measures |
+| --- | --- | --- |
+| `sync` | `POST /run/{service}` | End-user synchronous response time, throughput, and HTTP failures. |
+| `async` | `POST /job/{service}` | Job submission latency and, through OSCAR Manager logs, pre-run time, run time, completion time, and final job states. |
+
+For asynchronous calls, the HTTP response time only measures job acceptance. The end-to-end processing time is derived from OSCAR Manager timestamps:
+
+```text
+pre_run_seconds = start_time - creation_time
+run_seconds = finish_time - start_time
+completion_seconds = finish_time - creation_time
+```
+
+`pre_run_seconds` is deliberately broad. It measures the interval from job creation until OSCAR reports execution start, so it can include OSCAR controller reconciliation, Kueue admission, Kubernetes scheduling, image handling, and container startup. It should not be read as only "waiting because there were no free CPU or memory resources".
+
+## Invocation Baseline
+
+Before the Locust load steps, the suite can measure isolated baseline invocations:
+
+- First ready synchronous invocation through `POST /run/{service}`.
+- Warm synchronous invocation through a second immediate `POST /run/{service}`.
+- First ready asynchronous submission through `POST /job/{service}` plus job completion timing from OSCAR Manager logs.
+- Warm asynchronous submission through a second immediate `POST /job/{service}` plus job completion timing.
+
+This baseline is useful to compare isolated behavior against the load-test results. It is not a guaranteed node-level cold-start measurement. The suite waits until OSCAR reports the service as ready, and it does not control Docker image cache state on Kubernetes nodes.
+
+Some OSCAR deployments can expose the service token before the synchronous `/run/{service}` path is ready to accept traffic. To avoid recording that short readiness race as the baseline result, the synchronous baseline retries transient `502`, `503`, and `504` responses before giving up. The default retry window is controlled by `SCALABILITY_BASELINE_SYNC_RETRIES` and `SCALABILITY_BASELINE_SYNC_RETRY_INTERVAL`. When retries are used, `baseline.json` records the number of attempts, total elapsed time, and the failed transient attempts.
+
+The baseline is printed to the console and saved as:
+
+```text
+robot_results/scalability/experiments/<experiment-id>/baseline.json
+```
+
+## Async Warm-Up And Submit Pacing
+
+Before measured async Locust steps, the suite can submit a small number of warm-up jobs and wait for them to complete. This isolates short startup effects in OSCAR, Kueue, Kubernetes scheduling, image handling, and the service runtime from the measured async load steps.
+
+The warm-up result is saved as:
+
+```text
+robot_results/scalability/experiments/<experiment-id>/async-warmup.json
+```
+
+Async Locust steps also have their own wait interval. This prevents the async submit rate from being driven only by how quickly OSCAR accepts `/job` requests. With the default async wait of one second, each Locust user waits one second between async job submissions. Sync steps continue to use `LOCUST_WAIT_MIN` and `LOCUST_WAIT_MAX`.
+
+## Reproducibility Metadata
+
+Each experiment stores the non-secret configuration values used to launch the run:
+
+```text
+robot_results/scalability/experiments/<experiment-id>/run-configuration.json
+```
+
+This file includes:
+
+- The reconstructed `make test ...` command when the suite is launched through the Makefile helper.
+- The equivalent Robot command.
+- Referenced authentication and cluster variable file paths.
+- The OSCAR endpoint and generated service name.
+- The scalability variables that shape the experiment, such as `SCALABILITY_USERS`, `SCALABILITY_RUN_TIME`, `SCALABILITY_SERVICE_CPU`, `SCALABILITY_SERVICE_MEMORY`, `SCALABILITY_QUOTA_MODE`, and baseline settings.
+
+Bearer tokens and credential contents are not stored. Authentication and cluster files are referenced by path only.
+
+## Quota-Aware Load Planning
+
+By default, the suite reads the user's quota after creating the temporary service:
+
+```text
+GET /system/quotas/user
+```
+
+The service is created first because OSCAR/Kueue deployments may create the per-user `ClusterQueue` lazily on the first authenticated service operation. If the quota endpoint temporarily reports that the `ClusterQueue` is missing, the helper retries before falling back to the requested load steps unchanged.
+
+The quota values are normalized to CPU cores and MiB, then used to estimate a safe parallel capacity:
+
+```text
+cpu_parallel = floor(available_cpu_cores / SCALABILITY_SERVICE_CPU)
+memory_parallel = floor(available_memory_mib / SCALABILITY_SERVICE_MEMORY)
+safe_parallel = min(cpu_parallel, memory_parallel)
+```
+
+The effective load plan depends on `SCALABILITY_QUOTA_MODE`:
+
+| Mode | Behavior |
+| --- | --- |
+| `exploratory` | Keeps requested steps up to the safe capacity and the first requested step above it. This is useful to expose saturation points. |
+| `conservative` | Removes requested steps above the estimated safe capacity. This is useful for smoke or CI runs. |
+
+The plan is printed to the console and saved as:
+
+```text
+robot_results/scalability/experiments/<experiment-id>/quota-plan.json
+```
+
+Example console output:
+
+```text
+OSCAR scalability experiment
+Service: simple-test-dbl3 (1.0 CPU, 265Mi; parsed 1.0 CPU, 265.0 MiB)
+Requested user steps: 1,2,4
+Effective user steps: 1,2,4
+Run time per step: 30s; spawn rate: 1; async settle: 60s
+Cluster resources from /system/status: nodes=3; total_free_cpu=7.4 cores; max_node_free_cpu=3.1 cores; total_free_memory=18432.0 MiB; max_node_free_memory=8192.0 MiB
+Quota source: /system/quotas/user
+Quota raw max: cpu=2000, memory=2147483648
+Available quota: cpu=2.0 cores, memory=2048.0 MiB
+Estimated parallel capacity: cpu=20, memory=16, safe=16; mode=exploratory
+```
+
+## Configuration Variables
+
+### Understanding `SCALABILITY_USERS`
+
+`SCALABILITY_USERS` is a comma-separated list of Locust concurrent-user steps, not a list of OSCAR user accounts. For example, `SCALABILITY_USERS:1,2,4` means the suite will run one step with 1 concurrent Locust user, then one with 2 concurrent Locust users, then one with 4 concurrent Locust users.
+
+Each Locust user repeatedly invokes the same temporary `simple-test-*` service during the configured `SCALABILITY_RUN_TIME`. Higher values therefore increase the number of concurrent client-side invocation loops against OSCAR:
+
+- In `sync` mode, each Locust user sends synchronous `POST /run/{service}` requests and waits for the service response.
+- In `async` mode, each Locust user submits asynchronous jobs through `POST /job/{service}`. The suite later queries OSCAR Manager logs to derive pre-run, run, and completion timings.
+- `SCALABILITY_USERS` is quota-aware when `SCALABILITY_USE_QUOTAS=True`: the requested list may be reduced or extended according to `SCALABILITY_QUOTA_MODE` and the estimated safe parallel capacity.
+- The values are not equivalent to exact Kubernetes pod concurrency. They are the offered client load. Actual parallel execution depends on OSCAR scheduling, service resources, user quotas, cold starts, and cluster capacity.
+
+### Understanding `SCALABILITY_SPAWN_RATE`
+
+`SCALABILITY_SPAWN_RATE` is the Locust user ramp-up speed, expressed in users per second. The suite passes it directly to Locust as `-r`:
+
+```text
+locust ... -u <users> -r <SCALABILITY_SPAWN_RATE> -t <SCALABILITY_RUN_TIME>
+```
+
+It does not set requests per second. It only controls how quickly each Locust step reaches its target concurrency from `SCALABILITY_USERS`. For example, with `SCALABILITY_USERS:1,2,4`, `SCALABILITY_SPAWN_RATE:1`, and `SCALABILITY_RUN_TIME:30s`:
+
+- The 1-user step reaches its target in about 1 second.
+- The 2-user step reaches its target in about 2 seconds.
+- The 4-user step reaches its target in about 4 seconds.
+
+The remaining time in each step is the steady-state part of the measurement. If the target user count is high and the spawn rate is low, ramp-up can consume a large part of the configured run time. For example, a 32-user step with `SCALABILITY_SPAWN_RATE:1` takes about 32 seconds to reach 32 users, so a `SCALABILITY_RUN_TIME:30s` step may never spend meaningful time at full target concurrency.
+
+Use a low spawn rate when you want a gradual load increase and less abrupt pressure on OSCAR. Use a higher spawn rate when you want each step to reach the target concurrency quickly and measure mostly steady load. For small exploratory runs such as `SCALABILITY_USERS:1,2,4`, values of `1` or `2` are usually enough. For larger runs such as `1,2,4,8,16,32`, consider increasing either `SCALABILITY_SPAWN_RATE` or `SCALABILITY_RUN_TIME` so the largest steps have enough time at full concurrency.
+
+Common variables:
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `SCALABILITY_AUTH_MODE` | `user` | `user` uses the configured OIDC user bearer token for manager calls and invocations. `oscar` uses Basic auth from `BASIC_USER` in the cluster file for manager calls and the generated service token for `/run` and `/job`. |
+| `SCALABILITY_USERS` | `1,2,4` | Requested Locust concurrent-user steps. |
+| `SCALABILITY_SPAWN_RATE` | `1` | Locust user ramp-up speed in users per second. |
+| `SCALABILITY_RUN_TIME` | `30s` | Duration of each Locust step. |
+| `SCALABILITY_ASYNC_SETTLE_TIME` | `60s` | Time to wait after async load before collecting job status and timings. |
+| `SCALABILITY_ASYNC_WAIT_MIN` | `1` | Minimum seconds each async Locust user waits between `/job` submissions. |
+| `SCALABILITY_ASYNC_WAIT_MAX` | `1` | Maximum seconds each async Locust user waits between `/job` submissions. |
+| `SCALABILITY_SERVICE_CPU` | `1.0` | CPU requested by the temporary `simple-test` service. |
+| `SCALABILITY_SERVICE_MEMORY` | `265Mi` | Memory requested by the temporary `simple-test` service. |
+| `SCALABILITY_USE_QUOTAS` | `True` | Enables quota-aware load planning. |
+| `SCALABILITY_QUOTA_MODE` | `exploratory` | `exploratory` or `conservative`. |
+| `SCALABILITY_SYNC_ENABLED` | `True` | Enables synchronous steps. |
+| `SCALABILITY_ASYNC_ENABLED` | `True` | Enables asynchronous steps. |
+| `SCALABILITY_BASELINE_ENABLED` | `True` | Enables isolated first-ready and warm invocation measurements before Locust. |
+| `SCALABILITY_BASELINE_SYNC_RETRIES` | `15` | Additional retries for synchronous baseline calls when `/run/{service}` returns transient `502`, `503`, or `504` responses. |
+| `SCALABILITY_BASELINE_SYNC_RETRY_INTERVAL` | `2` | Seconds to wait between synchronous baseline retry attempts. |
+| `SCALABILITY_BASELINE_ASYNC_TIMEOUT` | `120` | Maximum seconds to wait for each baseline async job to reach a terminal state. |
+| `SCALABILITY_BASELINE_ASYNC_POLL_INTERVAL` | `2` | Seconds between OSCAR Manager log polls for baseline async jobs. |
+| `SCALABILITY_ASYNC_WARMUP_ENABLED` | `True` | Enables asynchronous warm-up jobs before measured async Locust steps. |
+| `SCALABILITY_ASYNC_WARMUP_JOBS` | `3` | Number of asynchronous warm-up jobs to submit and wait for. |
+| `SCALABILITY_ASYNC_WARMUP_SUBMIT_INTERVAL` | `1` | Seconds to wait between async warm-up job submissions. |
+| `SCALABILITY_CLEAN_JOBS` | `True` | Deletes jobs before async steps and during teardown. |
+| `SCALABILITY_CLEAN_SERVICE` | `True` | Deletes the temporary service during teardown. |
+
+Example with a larger exploratory run:
+
+```sh
+make test auth-keycloak-gmolto cluster-localhost \
+  ROBOT_SUITE=tests/scalability/scalability.robot \
+  ROBOT_ARGS="-v SCALABILITY_USERS:1,2,4,8,16,32 -v SCALABILITY_RUN_TIME:1m -v SCALABILITY_SPAWN_RATE:2 -v SCALABILITY_ASYNC_SETTLE_TIME:180s -v SCALABILITY_QUOTA_MODE:exploratory"
+```
+
+Example conservative run:
+
+```sh
+make test auth-keycloak-gmolto cluster-localhost \
+  ROBOT_SUITE=tests/scalability/scalability.robot \
+  ROBOT_ARGS="-v SCALABILITY_USERS:1,2,4,8,16,32 -v SCALABILITY_QUOTA_MODE:conservative"
+```
+
+Example run with the OSCAR `oscar` Basic-auth user configured in the cluster file:
+
+```sh
+make test auth-keycloak-gmolto cluster-eosc-dc \
+  ROBOT_SUITE=tests/scalability/scalability.robot \
+  ROBOT_ARGS="-v SCALABILITY_AUTH_MODE:oscar -v SCALABILITY_USERS:1,2,4 -v SCALABILITY_SERVICE_CPU:1.0 -v SCALABILITY_SERVICE_MEMORY:256Mi"
+```
+
+`SCALABILITY_AUTH_MODE:oscar` does not store credentials in the experiment artifacts. The generated `run-configuration.json` records only the selected mode and the referenced config file paths.
+
+## Output Artifacts
+
+The suite writes raw and normalized results under:
+
+```text
+robot_results/scalability/experiments/<experiment-id>/
+```
+
+Per-step Locust artifacts:
+
+```text
+<experiment-id>-sync-1u.html
+<experiment-id>-sync-1u_stats.csv
+<experiment-id>-sync-1u_stats_history.csv
+<experiment-id>-sync-1u_failures.csv
+<experiment-id>-sync-1u_exceptions.csv
+<experiment-id>-sync-1u_locust.json
+
+<experiment-id>-async-1u.html
+...
+```
+
+Per-step summaries:
+
+```text
+<experiment-id>-sync-1u_summary.json
+<experiment-id>-sync-1u_summary.md
+<experiment-id>-async-1u_summary.json
+<experiment-id>-async-1u_summary.md
+```
+
+Experiment artifacts:
+
+```text
+robot_results/scalability/experiments/<experiment-id>/experiment.json
+robot_results/scalability/experiments/<experiment-id>/quota-plan.json
+robot_results/scalability/experiments/<experiment-id>/cluster-status.json
+robot_results/scalability/experiments/<experiment-id>/baseline.json
+robot_results/scalability/experiments/<experiment-id>/async-warmup.json
+robot_results/scalability/experiments/<experiment-id>/run-configuration.json
+robot_results/scalability/experiments/index.json
+robot_results/scalability/viewer/index.html
+robot_results/scalability/viewer/data/experiments.js
+```
+
+The `<experiment-id>/experiment.json` file is the canonical result for one experiment. It includes:
+
+- Experiment metadata.
+- OSCAR cluster endpoint.
+- Deployed OSCAR service metadata, including the OSCAR Hub URL for `simple-test`.
+- Per-invocation CPU and memory requested by the service for the executed invocation modes.
+- The quota plan captured before the workload starts.
+- The initial `/system/status` cluster resource snapshot.
+- The isolated invocation baseline captured before Locust starts.
+- The async warm-up jobs captured before measured async Locust steps.
+- The run configuration metadata required to reproduce the test inputs.
+- Service resources.
+- Requested and effective load plan.
+- Synchronous and asynchronous step metrics.
+- Async job lifecycle timings and final statuses.
+- References to raw Locust and summary files.
+
+The canonical viewer template lives in `tests/scalability/viewer/`. The generated data file lives under `robot_results/scalability/viewer/data/experiments.js`, and the template loads it through a relative path. A portable copy of the viewer is still published into `robot_results/scalability/viewer/` on each run.
+
+## Cleaning Results
+
+Remove previous scalability experiments, Locust reports, stress API reports, and generated viewer data with:
+
+```sh
+make clean-scalability-results
+```
+
+This deletes:
+
+```text
+robot_results/scalability/
+```
+
+Remove all Robot Framework results with:
+
+```sh
+make clean-results
+```
+
+This deletes:
+
+```text
+robot_results/
+```
+
+Both cleanup targets honor `ROBOT_OUTPUT_DIR` if it is overridden.
+
+## Viewing Results
+
+Open the static D3 viewer:
+
+```sh
+open tests/scalability/viewer/index.html
+```
+
+The viewer can display one or more experiment JSON files listed in:
+
+```text
+robot_results/scalability/experiments/index.json
+```
+
+It currently shows:
+
+- Experiment overview.
+- Platform baseline split into deployed service resources, cluster resource data from `/system/status`, and user quota data from `/system/quotas/user`.
+- Invocation baseline for first-ready and warm isolated calls.
+- Automatically generated key findings.
+- Step-by-step summary table.
+- Throughput vs load.
+- Invocation P95 latency.
+- HTTP failure rate.
+- Async job pre-run and run P95 timings.
+- Job status composition.
+- Header tooltips explaining the main table metrics.
+- Reproducibility command captured when the experiment was launched.
+
+Because the viewer loads `robot_results/scalability/viewer/data/experiments.js` directly, it can be opened from the source tree without copying result files into `tests/scalability/viewer/` and without running a web server.
+
+## Rebuilding The Experiment Viewer
+
+If raw artifacts already exist, rebuild the experiment JSON and republish the viewer with:
+
+```sh
+python3 tests/scalability/src/build_experiment.py \
+  --experiment-dir robot_results/scalability/experiments/<experiment-id> \
+  --output-root robot_results/scalability \
+  --service <service-name> \
+  --viewer-src tests/scalability/viewer \
+  --endpoint <oscar-endpoint>
+```
+
+For example:
+
+```sh
+python3 tests/scalability/src/build_experiment.py \
+  --experiment-dir robot_results/scalability/experiments/simple-test-dbl3 \
+  --output-root robot_results/scalability \
+  --service simple-test-dbl3 \
+  --viewer-src tests/scalability/viewer \
+  --endpoint https://oscar.example.com
+```
+
+## Interpreting Results
+
+For synchronous invocations:
+
+- The invocation baseline shows first-ready and warm isolated `/run` latency before client load is applied.
+- Throughput should grow with users until the platform saturates.
+- P95/P99 latency jumps indicate pressure even if there are no HTTP failures.
+- HTTP `400`, `500`, or timeout failures mark overload or admission problems.
+
+For asynchronous invocations:
+
+- The invocation baseline shows isolated `/job` submit latency and end-to-end job completion timing before client load is applied.
+- `POST /job` latency is submission latency, not job completion latency.
+- Pre-run time growth indicates delay before OSCAR reports execution start. It may come from controller reconciliation, admission, scheduling, image handling, container startup, or quota pressure.
+- Run time growth may indicate execution contention.
+- Unfinished jobs after `SCALABILITY_ASYNC_SETTLE_TIME` can mean saturation, or simply that the settle time was too short.
+- Job status composition is often more useful than submission latency for detecting async saturation.
+
+For quota-aware experiments:
+
+- If all requested steps are below `safe_parallel`, the run mainly measures behavior within expected capacity.
+- In `exploratory` mode, the first step above `safe_parallel` is useful to demonstrate the saturation boundary.
+- In `conservative` mode, steps above `safe_parallel` are skipped.
+
+## API Stress Suite
+
+The API stress suite is separate from service invocation scalability:
+
+```sh
+make test auth-keycloak-gmolto cluster-localhost \
+  ROBOT_SUITE=tests/scalability/stress-api.robot
+```
+
+It exercises OSCAR Manager API endpoints through Locust and writes artifacts under:
+
+```text
+robot_results/scalability/stress-api/
+```
+
+Open the latest stress API Locust report:
+
+```sh
+open "$(ls -t robot_results/scalability/stress-api/*.html | head -1)"
+```

--- a/tests/scalability/scalability.robot
+++ b/tests/scalability/scalability.robot
@@ -1,0 +1,519 @@
+*** Settings ***
+Documentation       Scalability tests for OSCAR service invocations executed through Locust.
+
+Resource            ${CURDIR}/../../${AUTHENTICATION_PROCESS}
+Resource            ${CURDIR}/../../resources/files.resource
+Resource            ${CURDIR}/../../resources/service.resource
+Library             Collections
+Library             OperatingSystem
+Library             Process
+Library             RequestsLibrary
+Library             String
+
+Suite Setup         Setup Scalability Environment
+Suite Teardown      Teardown Scalability Environment
+
+
+*** Variables ***
+${SCALABILITY_SRC_DIR}              ${CURDIR}/src
+${LOCUSTFILE}                       ${SCALABILITY_SRC_DIR}/oscar_invocations.py
+${COLLECTOR}                        ${SCALABILITY_SRC_DIR}/collect_scalability_results.py
+${LOAD_PLANNER}                     ${SCALABILITY_SRC_DIR}/plan_scalability_load.py
+${CLUSTER_STATUS_CAPTURE}           ${SCALABILITY_SRC_DIR}/capture_cluster_status.py
+${BASELINE_MEASURER}                ${SCALABILITY_SRC_DIR}/measure_baseline_invocations.py
+${ASYNC_WARMUP}                     ${SCALABILITY_SRC_DIR}/warm_async_invocations.py
+${RUN_CONFIG_WRITER}                ${SCALABILITY_SRC_DIR}/write_run_configuration.py
+${EXPERIMENT_BUILDER}               ${SCALABILITY_SRC_DIR}/build_experiment.py
+${SCALABILITY_VIEWER_DIR}           ${CURDIR}/viewer
+${SCALABILITY_SERVICE_FILE}         ${DATA_DIR}/simple-test.yaml
+${SCALABILITY_SERVICE_SCRIPT}       ${DATA_DIR}/simple-test-script.sh
+${SCALABILITY_SERVICE_JSON}         ${DATA_DIR}/simple-test-scalability.json
+${SCALABILITY_SERVICE_BASE}         simple-test
+${SCALABILITY_SERVICE_NAME}         ${SCALABILITY_SERVICE_BASE}
+${SCALABILITY_PAYLOAD_FILE}         ${DATA_DIR}/simple-test-input.payload
+${SCALABILITY_OUTPUT_DIR}           ${EXECDIR}/robot_results/scalability
+${SCALABILITY_EXPERIMENTS_DIR}      ${SCALABILITY_OUTPUT_DIR}/experiments
+${SCALABILITY_EXPERIMENT_DIR}       ${EMPTY}
+${SCALABILITY_USERS}                1,2,4
+${SCALABILITY_SPAWN_RATE}           1
+${SCALABILITY_RUN_TIME}             30s
+${SCALABILITY_ASYNC_SETTLE_TIME}    60s
+${SCALABILITY_ASYNC_WAIT_MIN}       1
+${SCALABILITY_ASYNC_WAIT_MAX}       1
+${SCALABILITY_SERVICE_CPU}          1.0
+${SCALABILITY_SERVICE_MEMORY}       265Mi
+${SCALABILITY_USE_QUOTAS}           ${True}
+${SCALABILITY_QUOTA_MODE}           exploratory
+${SCALABILITY_EFFECTIVE_USERS}      ${SCALABILITY_USERS}
+${SCALABILITY_CLUSTER_RESOURCES}    ${None}
+${SCALABILITY_AUTH_MODE}            user
+${SCALABILITY_AUTH_HEADER}          ${EMPTY}
+${SCALABILITY_INVOCATION_AUTH_HEADER}       ${EMPTY}
+${SCALABILITY_INVOCATION_AUTH_SOURCE}       ${EMPTY}
+${SCALABILITY_SYNC_ENABLED}         ${True}
+${SCALABILITY_ASYNC_ENABLED}        ${True}
+${SCALABILITY_BASELINE_ENABLED}     ${True}
+${SCALABILITY_BASELINE_SYNC_RETRIES}        15
+${SCALABILITY_BASELINE_SYNC_RETRY_INTERVAL}     2
+${SCALABILITY_BASELINE_ASYNC_TIMEOUT}       120
+${SCALABILITY_BASELINE_ASYNC_POLL_INTERVAL}     2
+${SCALABILITY_ASYNC_WARMUP_ENABLED}     ${True}
+${SCALABILITY_ASYNC_WARMUP_JOBS}        3
+${SCALABILITY_ASYNC_WARMUP_SUBMIT_INTERVAL}     1
+${SCALABILITY_CLEAN_JOBS}           ${True}
+${SCALABILITY_CLEAN_SERVICE}        ${True}
+${LOCUST_WAIT_MIN}                  0
+${LOCUST_WAIT_MAX}                  0
+
+
+*** Test Cases ***
+OSCAR Sync Invocation Scalability
+    [Documentation]    Measure synchronous service invocation through POST /run/{service}.
+    [Tags]    scalability    sync
+    Skip If    not ${SCALABILITY_SYNC_ENABLED}
+    Run Scalability Steps    sync
+
+OSCAR Async Invocation Scalability
+    [Documentation]    Measure asynchronous job submission through POST /job/{service} and collect job states afterwards.
+    [Tags]    scalability    async
+    Skip If    not ${SCALABILITY_ASYNC_ENABLED}
+    Run Scalability Steps    async
+
+
+*** Keywords ***
+Setup Scalability Environment
+    [Documentation]    Create a simple-test based service and export environment variables consumed by Locust.
+    ${service_name}=    Generate Random Service Name    ${SCALABILITY_SERVICE_BASE}
+    Set Suite Variable    ${SCALABILITY_SERVICE_NAME}    ${service_name}
+    Create Directory    ${SCALABILITY_OUTPUT_DIR}
+    Create Directory    ${SCALABILITY_EXPERIMENTS_DIR}
+    ${experiment_dir}=    Catenate    SEPARATOR=/    ${SCALABILITY_EXPERIMENTS_DIR}    ${SCALABILITY_SERVICE_NAME}
+    Set Suite Variable    ${SCALABILITY_EXPERIMENT_DIR}    ${experiment_dir}
+    Create Directory    ${SCALABILITY_EXPERIMENT_DIR}
+    Configure Scalability Authentication
+    Capture Cluster Status Snapshot
+    Prepare Simple Test Service File
+    ${body}=    Get File    ${SCALABILITY_SERVICE_JSON}
+    ${response}=    POST With Defaults    url=${OSCAR_ENDPOINT}/system/services    data=${body}
+    Should Be True    '${response.status_code}' == '201' or '${response.status_code}' == '409'
+    Wait For Scalability Service Ready
+    Configure Scalability Invocation Authentication
+    Plan Scalability Load From Quotas
+    Run Keyword If    ${SCALABILITY_BASELINE_ENABLED}    Measure Baseline Invocations
+    Capture Run Configuration
+    Run Keyword If    ${SCALABILITY_BASELINE_ENABLED} and ${SCALABILITY_CLEAN_JOBS}    Delete Scalability Jobs
+    ${payload}=    Get File    ${SCALABILITY_PAYLOAD_FILE}
+    Set Environment Variable    OSCAR_SERVICE_NAME    ${SCALABILITY_SERVICE_NAME}
+    Set Environment Variable    SCALABILITY_PAYLOAD    ${payload}
+    Set Environment Variable    LOCUST_WAIT_MIN    ${LOCUST_WAIT_MIN}
+    Set Environment Variable    LOCUST_WAIT_MAX    ${LOCUST_WAIT_MAX}
+
+Teardown Scalability Environment
+    [Documentation]    Remove service, generated payloads, and environment variables.
+    Run Keyword And Ignore Error    Build Scalability Experiment Artifact
+    Run Keyword If    ${SCALABILITY_CLEAN_JOBS}    Delete Scalability Jobs
+    Run Keyword If    ${SCALABILITY_CLEAN_SERVICE}    Delete Scalability Service
+    Run Keyword And Ignore Error    Remove File    ${SCALABILITY_SERVICE_JSON}
+    Run Keyword And Ignore Error    Remove Environment Variable    OSCAR_SERVICE_NAME
+    Run Keyword And Ignore Error    Remove Environment Variable    OSCAR_ACCESS_TOKEN
+    Run Keyword And Ignore Error    Remove Environment Variable    OSCAR_AUTHORIZATION_HEADER
+    Run Keyword And Ignore Error    Remove Environment Variable    OSCAR_INVOCATION_AUTHORIZATION_HEADER
+    Run Keyword And Ignore Error    Remove Environment Variable    OSCAR_LOAD_MODE
+    Run Keyword And Ignore Error    Remove Environment Variable    SCALABILITY_PAYLOAD
+    Run Keyword And Ignore Error    Remove Environment Variable    LOCUST_WAIT_MIN
+    Run Keyword And Ignore Error    Remove Environment Variable    LOCUST_WAIT_MAX
+
+Run Scalability Steps
+    [Documentation]    Execute one Locust run per user-count step.
+    [Arguments]    ${mode}
+    @{steps}=    Split String    ${SCALABILITY_EFFECTIVE_USERS}    ,
+    Run Keyword If    '${mode}' == 'async' and ${SCALABILITY_ASYNC_WARMUP_ENABLED}    Run Async Warmup
+    FOR    ${users}    IN    @{steps}
+        ${users}=    Strip String    ${users}
+        Log To Console    OSCAR scalability step: mode=${mode}, users=${users}, run_time=${SCALABILITY_RUN_TIME}, spawn_rate=${SCALABILITY_SPAWN_RATE}
+        Run Keyword If    '${mode}' == 'async' and ${SCALABILITY_CLEAN_JOBS}    Delete Scalability Jobs
+        Run Locust Invocation Test    ${mode}    ${users}
+        Run Keyword If    '${mode}' == 'async'    Sleep    ${SCALABILITY_ASYNC_SETTLE_TIME}
+        Collect Scalability Results    ${mode}    ${users}
+    END
+
+Run Locust Invocation Test
+    [Documentation]    Execute Locust headlessly for a single scalability step.
+    [Arguments]    ${mode}    ${users}
+    Set Environment Variable    OSCAR_LOAD_MODE    ${mode}
+    Configure Locust Wait For Mode    ${mode}
+    ${output_prefix}=    Get Scalability Output Prefix    ${mode}    ${users}
+    ${command}=    Create List    locust    -f    ${LOCUSTFILE}    --headless    -u    ${users}
+    ...    -r    ${SCALABILITY_SPAWN_RATE}    -t    ${SCALABILITY_RUN_TIME}    --host=${OSCAR_ENDPOINT}
+    ...    --stop-timeout=60    --csv=${output_prefix}    --csv-full-history    --html=${output_prefix}.html
+    ...    --json-file=${output_prefix}_locust    --exit-code-on-error=0
+    ${result}=    Run Process    @{command}    stdout=True    stderr=True    cwd=${CURDIR}
+    Log    ${result.stdout}
+    Log    ${result.stderr}
+    Should Be Equal As Integers    ${result.rc}    0
+    Log    Locust artifacts written using prefix ${output_prefix}
+
+Configure Locust Wait For Mode
+    [Documentation]    Use async-specific pacing so job submit rate is not tied only to HTTP acceptance latency.
+    [Arguments]    ${mode}
+    IF    '${mode}' == 'async'
+        Set Environment Variable    LOCUST_WAIT_MIN    ${SCALABILITY_ASYNC_WAIT_MIN}
+        Set Environment Variable    LOCUST_WAIT_MAX    ${SCALABILITY_ASYNC_WAIT_MAX}
+        Log    Async Locust wait configured: min=${SCALABILITY_ASYNC_WAIT_MIN}, max=${SCALABILITY_ASYNC_WAIT_MAX}
+    ELSE
+        Set Environment Variable    LOCUST_WAIT_MIN    ${LOCUST_WAIT_MIN}
+        Set Environment Variable    LOCUST_WAIT_MAX    ${LOCUST_WAIT_MAX}
+        Log    Locust wait configured: min=${LOCUST_WAIT_MIN}, max=${LOCUST_WAIT_MAX}
+    END
+
+Configure Scalability Authentication
+    [Documentation]    Configure either OIDC user bearer auth or OSCAR Basic auth for OSCAR Manager operations.
+    ${auth_mode}=    Convert To Lower Case    ${SCALABILITY_AUTH_MODE}
+    IF    '${auth_mode}' == 'oscar' or '${auth_mode}' == 'basic' or '${auth_mode}' == 'admin'
+        Variable Should Exist    ${BASIC_USER}    BASIC_USER must be defined in the selected cluster file to use SCALABILITY_AUTH_MODE=oscar.
+        VAR    &{HEADERS}=    Authorization=Basic ${BASIC_USER}    Content-Type=text/json    Accept=application/json
+        ...    scope=SUITE
+        VAR    &{HEADERS_OSCAR}=    Authorization=Basic ${BASIC_USER}    Content-Type=text/json    Accept=application/json
+        ...    scope=SUITE
+        Set Suite Variable    ${ACCESS_TOKEN}    ${EMPTY}
+        Set Suite Variable    ${USER}    oscar
+        Set Suite Variable    ${USER_SHORT_ID}    oscar
+    ELSE
+        Check Valid OIDC Token
+        ${access_token}=    Get Access Token
+        Set Suite Variable    ${ACCESS_TOKEN}    ${access_token}
+    END
+    ${auth_header}=    Get From Dictionary    ${HEADERS}    Authorization
+    Set Suite Variable    ${SCALABILITY_AUTH_HEADER}    ${auth_header}
+    Set Environment Variable    OSCAR_AUTHORIZATION_HEADER    ${SCALABILITY_AUTH_HEADER}
+    Run Keyword If    '${ACCESS_TOKEN}' != ''    Set Environment Variable    OSCAR_ACCESS_TOKEN    ${ACCESS_TOKEN}
+    Log To Console    Scalability authentication mode: ${auth_mode}
+    Run Keyword If    '${auth_mode}' == 'oscar' or '${auth_mode}' == 'basic' or '${auth_mode}' == 'admin'    Validate OSCAR Basic Authentication
+
+Configure Scalability Invocation Authentication
+    [Documentation]    Configure the Authorization header used by /run and /job invocations.
+    ${auth_mode}=    Convert To Lower Case    ${SCALABILITY_AUTH_MODE}
+    IF    '${auth_mode}' == 'oscar' or '${auth_mode}' == 'basic' or '${auth_mode}' == 'admin'
+        ${response}=    GET With Defaults    url=${OSCAR_ENDPOINT}/system/services/${SCALABILITY_SERVICE_NAME}    expected_status=200
+        ${previous_log_level}=    Set Log Level    NONE
+        ${service_token}=    Evaluate    json.loads($response.content).get("token")    json
+        Should Not Be Empty
+        ...    ${service_token}
+        ...    msg=The service ${SCALABILITY_SERVICE_NAME} does not expose an invocation token. Cannot invoke /run or /job with SCALABILITY_AUTH_MODE=${SCALABILITY_AUTH_MODE}.
+        ${invocation_header}=    Set Variable    Bearer ${service_token}
+        Set Suite Variable    ${SCALABILITY_INVOCATION_AUTH_SOURCE}    service-token
+    ELSE
+        ${previous_log_level}=    Set Log Level    NONE
+        ${invocation_header}=    Set Variable    ${SCALABILITY_AUTH_HEADER}
+        Set Suite Variable    ${SCALABILITY_INVOCATION_AUTH_SOURCE}    user-bearer
+    END
+    Set Suite Variable    ${SCALABILITY_INVOCATION_AUTH_HEADER}    ${invocation_header}
+    Set Environment Variable    OSCAR_INVOCATION_AUTHORIZATION_HEADER    ${SCALABILITY_INVOCATION_AUTH_HEADER}
+    Set Log Level    ${previous_log_level}
+    Log To Console    Scalability invocation authentication: ${SCALABILITY_INVOCATION_AUTH_SOURCE}
+
+Capture Cluster Status Snapshot
+    [Documentation]    Store a non-blocking /system/status snapshot before the experiment workload starts.
+    ${status_path}=    Catenate    SEPARATOR=/    ${SCALABILITY_EXPERIMENT_DIR}    cluster-status.json
+    ${command}=    Create List    python3    ${CLUSTER_STATUS_CAPTURE}
+    ...    --endpoint    ${OSCAR_ENDPOINT}
+    ...    --output    ${status_path}
+    ...    --ssl-verify    ${SSL_VERIFY}
+    ${result}=    Run Process    @{command}    stdout=True    stderr=True    cwd=${CURDIR}
+    Log    ${result.stdout}
+    Log    ${result.stderr}
+    Should Be Equal As Integers    ${result.rc}    0
+    ${snapshot}=    Evaluate    json.loads($result.stdout)    json
+    ${resources}=    Evaluate    $snapshot.get("resources", {})
+    Set Suite Variable    ${SCALABILITY_CLUSTER_RESOURCES}    ${resources}
+    ${available}=    Get From Dictionary    ${snapshot}    available
+    ${status_code}=    Get From Dictionary    ${snapshot}    status_code
+    ${cpu_total_free}=    Evaluate    $resources.get("cpu", {}).get("total_free_cores")
+    ${cpu_max_node_free}=    Evaluate    $resources.get("cpu", {}).get("max_free_on_node_cores")
+    ${memory_total_free}=    Evaluate    $resources.get("memory", {}).get("total_free_mib")
+    ${memory_max_node_free}=    Evaluate    $resources.get("memory", {}).get("max_free_on_node_mib")
+    Log To Console    Cluster status snapshot: available=${available}, status_code=${status_code}; total_free_cpu=${cpu_total_free} cores; max_node_free_cpu=${cpu_max_node_free} cores; total_free_memory=${memory_total_free} MiB; max_node_free_memory=${memory_max_node_free} MiB; saved to ${status_path}
+
+Validate OSCAR Basic Authentication
+    [Documentation]    Fail fast when BASIC_USER from the cluster file is rejected by OSCAR.
+    ${response}=    GET With Defaults    url=${OSCAR_ENDPOINT}/system/services    expected_status=ANY
+    Should Be Equal As Integers
+    ...    ${response.status_code}
+    ...    200
+    ...    msg=SCALABILITY_AUTH_MODE=oscar selected, but OSCAR rejected BASIC_USER from the cluster file at ${OSCAR_ENDPOINT}/system/services with HTTP ${response.status_code}. Check that the cluster file contains current oscar Basic auth credentials and that Basic auth is enabled on this endpoint.
+    Log To Console    OSCAR Basic authentication validated for ${OSCAR_ENDPOINT}
+
+Plan Scalability Load From Quotas
+    [Documentation]    Compute the user-step plan from /system/quotas/user and print experiment metadata.
+    IF    not ${SCALABILITY_USE_QUOTAS}
+        Set Suite Variable    ${SCALABILITY_EFFECTIVE_USERS}    ${SCALABILITY_USERS}
+        Log To Console    OSCAR scalability experiment: quotas disabled; users=${SCALABILITY_EFFECTIVE_USERS}; service_cpu=${SCALABILITY_SERVICE_CPU}; service_memory=${SCALABILITY_SERVICE_MEMORY}
+        RETURN
+    END
+    ${command}=    Create List    python3    ${LOAD_PLANNER}
+    ...    --endpoint    ${OSCAR_ENDPOINT}
+    ...    --requested-users    ${SCALABILITY_USERS}
+    ...    --service-cpu    ${SCALABILITY_SERVICE_CPU}
+    ...    --service-memory    ${SCALABILITY_SERVICE_MEMORY}
+    ...    --mode    ${SCALABILITY_QUOTA_MODE}
+    ...    --ssl-verify    ${SSL_VERIFY}
+    ${result}=    Run Process    @{command}    stdout=True    stderr=True    cwd=${CURDIR}
+    Log    ${result.stdout}
+    Log    ${result.stderr}
+    Should Be Equal As Integers    ${result.rc}    0
+    ${plan}=    Evaluate    json.loads($result.stdout)    json
+    ${effective_users}=    Evaluate    ",".join(str(item) for item in $plan["effective_users"])
+    Set Suite Variable    ${SCALABILITY_EFFECTIVE_USERS}    ${effective_users}
+    ${plan_path}=    Catenate    SEPARATOR=/    ${SCALABILITY_EXPERIMENT_DIR}    quota-plan.json
+    Create File    ${plan_path}    ${result.stdout}
+    Print Scalability Experiment Plan    ${plan}    ${plan_path}
+
+Print Scalability Experiment Plan
+    [Arguments]    ${plan}    ${plan_path}
+    ${quota_available}=    Get From Dictionary    ${plan}    quota_available
+    ${requested_users}=    Evaluate    ",".join(str(item) for item in $plan["requested_users"])
+    ${effective_users}=    Evaluate    ",".join(str(item) for item in $plan["effective_users"])
+    ${service_cpu}=    Evaluate    $plan["service"]["cpu"]
+    ${service_memory}=    Evaluate    $plan["service"]["memory_mib"]
+    Log To Console    \nOSCAR scalability experiment
+    Log To Console    Service: ${SCALABILITY_SERVICE_NAME} (${SCALABILITY_SERVICE_CPU} CPU, ${SCALABILITY_SERVICE_MEMORY}; parsed ${service_cpu} CPU, ${service_memory} MiB)
+    Log To Console    Requested user steps: ${requested_users}
+    Log To Console    Effective user steps: ${effective_users}
+    Log To Console    Run time per step: ${SCALABILITY_RUN_TIME}; spawn rate: ${SCALABILITY_SPAWN_RATE}; async settle: ${SCALABILITY_ASYNC_SETTLE_TIME}
+    ${has_cluster_resources}=    Evaluate    isinstance($SCALABILITY_CLUSTER_RESOURCES, dict) and bool($SCALABILITY_CLUSTER_RESOURCES)
+    IF    ${has_cluster_resources}
+        ${nodes_count}=    Evaluate    $SCALABILITY_CLUSTER_RESOURCES.get("nodes_count")
+        ${cluster_cpu_total_free}=    Evaluate    $SCALABILITY_CLUSTER_RESOURCES.get("cpu", {}).get("total_free_cores")
+        ${cluster_cpu_max_node_free}=    Evaluate    $SCALABILITY_CLUSTER_RESOURCES.get("cpu", {}).get("max_free_on_node_cores")
+        ${cluster_memory_total_free}=    Evaluate    $SCALABILITY_CLUSTER_RESOURCES.get("memory", {}).get("total_free_mib")
+        ${cluster_memory_max_node_free}=    Evaluate    $SCALABILITY_CLUSTER_RESOURCES.get("memory", {}).get("max_free_on_node_mib")
+        Log To Console    Cluster resources from /system/status: nodes=${nodes_count}; total_free_cpu=${cluster_cpu_total_free} cores; max_node_free_cpu=${cluster_cpu_max_node_free} cores; total_free_memory=${cluster_memory_total_free} MiB; max_node_free_memory=${cluster_memory_max_node_free} MiB
+    END
+    IF    ${quota_available}
+        ${quota_path}=    Get From Dictionary    ${plan}    quota_path
+        ${cpu_max_raw}=    Evaluate    $plan["quota"]["cpu_max_raw"]
+        ${memory_max_raw}=    Evaluate    $plan["quota"]["memory_max_raw"]
+        ${cpu_available}=    Evaluate    $plan["quota"]["cpu_available"]
+        ${memory_available}=    Evaluate    $plan["quota"]["memory_available_mib"]
+        ${safe_parallel}=    Evaluate    $plan["limits"]["safe_parallel"]
+        ${cpu_parallel}=    Evaluate    $plan["limits"]["cpu_parallel"]
+        ${memory_parallel}=    Evaluate    $plan["limits"]["memory_parallel"]
+        Log To Console    Quota source: ${quota_path}
+        Log To Console    Quota raw max: cpu=${cpu_max_raw}, memory=${memory_max_raw}
+        Log To Console    Available quota: cpu=${cpu_available} cores, memory=${memory_available} MiB
+        Log To Console    Estimated parallel capacity: cpu=${cpu_parallel}, memory=${memory_parallel}, safe=${safe_parallel}; mode=${SCALABILITY_QUOTA_MODE}
+    ELSE
+        ${reason}=    Get From Dictionary    ${plan}    reason
+        Log To Console    Quota source: unavailable (${reason}); using requested user steps unchanged
+    END
+    Log To Console    Quota plan saved to: ${plan_path}
+
+Measure Baseline Invocations
+    [Documentation]    Measure first-ready and warm isolated invocations before Locust load.
+    ${baseline_path}=    Catenate    SEPARATOR=/    ${SCALABILITY_EXPERIMENT_DIR}    baseline.json
+    ${command}=    Create List    python3    ${BASELINE_MEASURER}
+    ...    --endpoint    ${OSCAR_ENDPOINT}
+    ...    --service    ${SCALABILITY_SERVICE_NAME}
+    ...    --payload-file    ${SCALABILITY_PAYLOAD_FILE}
+    ...    --output    ${baseline_path}
+    ...    --ssl-verify    ${SSL_VERIFY}
+    ...    --sync-retries    ${SCALABILITY_BASELINE_SYNC_RETRIES}
+    ...    --sync-retry-interval    ${SCALABILITY_BASELINE_SYNC_RETRY_INTERVAL}
+    ...    --async-timeout    ${SCALABILITY_BASELINE_ASYNC_TIMEOUT}
+    ...    --async-poll-interval    ${SCALABILITY_BASELINE_ASYNC_POLL_INTERVAL}
+    ${result}=    Run Process    @{command}    stdout=True    stderr=True    cwd=${CURDIR}
+    Log    ${result.stdout}
+    Log    ${result.stderr}
+    Should Be Equal As Integers    ${result.rc}    0
+    ${baseline}=    Evaluate    json.loads($result.stdout)    json
+    ${sync_first_ms}=    Evaluate    $baseline.get("sync", {}).get("first_ready", {}).get("latency_ms")
+    ${sync_warm_ms}=    Evaluate    $baseline.get("sync", {}).get("warm", {}).get("latency_ms")
+    ${sync_first_attempts}=    Evaluate    $baseline.get("sync", {}).get("first_ready", {}).get("attempts")
+    ${sync_warm_attempts}=    Evaluate    $baseline.get("sync", {}).get("warm", {}).get("attempts")
+    ${async_first_submit_ms}=    Evaluate    $baseline.get("async", {}).get("first_ready", {}).get("submit", {}).get("latency_ms")
+    ${async_first_e2e_s}=    Evaluate    $baseline.get("async", {}).get("first_ready", {}).get("job", {}).get("completion_seconds")
+    ${async_warm_submit_ms}=    Evaluate    $baseline.get("async", {}).get("warm", {}).get("submit", {}).get("latency_ms")
+    ${async_warm_e2e_s}=    Evaluate    $baseline.get("async", {}).get("warm", {}).get("job", {}).get("completion_seconds")
+    Log To Console    Invocation baseline: sync_first_ready=${sync_first_ms} ms (${sync_first_attempts} attempts); sync_warm=${sync_warm_ms} ms (${sync_warm_attempts} attempts); async_first_submit=${async_first_submit_ms} ms; async_first_e2e=${async_first_e2e_s} s; async_warm_submit=${async_warm_submit_ms} ms; async_warm_e2e=${async_warm_e2e_s} s; saved to ${baseline_path}
+
+Run Async Warmup
+    [Documentation]    Submit and wait for warm-up async jobs before measured async Locust steps.
+    ${warmup_path}=    Catenate    SEPARATOR=/    ${SCALABILITY_EXPERIMENT_DIR}    async-warmup.json
+    ${command}=    Create List    python3    ${ASYNC_WARMUP}
+    ...    --endpoint    ${OSCAR_ENDPOINT}
+    ...    --service    ${SCALABILITY_SERVICE_NAME}
+    ...    --payload-file    ${SCALABILITY_PAYLOAD_FILE}
+    ...    --output    ${warmup_path}
+    ...    --ssl-verify    ${SSL_VERIFY}
+    ...    --jobs    ${SCALABILITY_ASYNC_WARMUP_JOBS}
+    ...    --submit-interval    ${SCALABILITY_ASYNC_WARMUP_SUBMIT_INTERVAL}
+    ...    --async-timeout    ${SCALABILITY_BASELINE_ASYNC_TIMEOUT}
+    ...    --async-poll-interval    ${SCALABILITY_BASELINE_ASYNC_POLL_INTERVAL}
+    ${result}=    Run Process    @{command}    stdout=True    stderr=True    cwd=${CURDIR}
+    Log    ${result.stdout}
+    Log    ${result.stderr}
+    Should Be Equal As Integers    ${result.rc}    0
+    ${warmup}=    Evaluate    json.loads($result.stdout)    json
+    ${summary}=    Evaluate    $warmup.get("summary", {})
+    ${warmup_jobs}=    Evaluate    $summary.get("jobs")
+    ${warmup_succeeded}=    Evaluate    $summary.get("succeeded")
+    ${warmup_elapsed}=    Evaluate    $summary.get("elapsed_seconds")
+    Log To Console    Async warm-up: jobs=${warmup_jobs}, succeeded=${warmup_succeeded}, elapsed=${warmup_elapsed} s; saved to ${warmup_path}
+    Run Keyword If    ${SCALABILITY_CLEAN_JOBS}    Delete Scalability Jobs
+
+Capture Run Configuration
+    [Documentation]    Store non-secret variables and command metadata required to reproduce the experiment.
+    ${config_path}=    Catenate    SEPARATOR=/    ${SCALABILITY_EXPERIMENT_DIR}    run-configuration.json
+    ${command}=    Create List    python3    ${RUN_CONFIG_WRITER}
+    ...    --output    ${config_path}
+    ...    --endpoint    ${OSCAR_ENDPOINT}
+    ...    --service    ${SCALABILITY_SERVICE_NAME}
+    ...    --experiment-dir    ${SCALABILITY_EXPERIMENT_DIR}
+    ...    --variable    OSCAR_ENDPOINT=${OSCAR_ENDPOINT}
+    ...    --variable    AUTHENTICATION_PROCESS=${AUTHENTICATION_PROCESS}
+    ...    --variable    SCALABILITY_AUTH_MODE=${SCALABILITY_AUTH_MODE}
+    ...    --variable    SCALABILITY_INVOCATION_AUTH_SOURCE=${SCALABILITY_INVOCATION_AUTH_SOURCE}
+    ...    --variable    SSL_VERIFY=${SSL_VERIFY}
+    ...    --variable    LOCAL_TESTING=${LOCAL_TESTING}
+    ...    --variable    SCALABILITY_USERS=${SCALABILITY_USERS}
+    ...    --variable    SCALABILITY_EFFECTIVE_USERS=${SCALABILITY_EFFECTIVE_USERS}
+    ...    --variable    SCALABILITY_SPAWN_RATE=${SCALABILITY_SPAWN_RATE}
+    ...    --variable    SCALABILITY_RUN_TIME=${SCALABILITY_RUN_TIME}
+    ...    --variable    SCALABILITY_ASYNC_SETTLE_TIME=${SCALABILITY_ASYNC_SETTLE_TIME}
+    ...    --variable    SCALABILITY_ASYNC_WAIT_MIN=${SCALABILITY_ASYNC_WAIT_MIN}
+    ...    --variable    SCALABILITY_ASYNC_WAIT_MAX=${SCALABILITY_ASYNC_WAIT_MAX}
+    ...    --variable    SCALABILITY_SERVICE_BASE=${SCALABILITY_SERVICE_BASE}
+    ...    --variable    SCALABILITY_SERVICE_NAME=${SCALABILITY_SERVICE_NAME}
+    ...    --variable    SCALABILITY_SERVICE_CPU=${SCALABILITY_SERVICE_CPU}
+    ...    --variable    SCALABILITY_SERVICE_MEMORY=${SCALABILITY_SERVICE_MEMORY}
+    ...    --variable    SCALABILITY_PAYLOAD_FILE=${SCALABILITY_PAYLOAD_FILE}
+    ...    --variable    SCALABILITY_USE_QUOTAS=${SCALABILITY_USE_QUOTAS}
+    ...    --variable    SCALABILITY_QUOTA_MODE=${SCALABILITY_QUOTA_MODE}
+    ...    --variable    SCALABILITY_SYNC_ENABLED=${SCALABILITY_SYNC_ENABLED}
+    ...    --variable    SCALABILITY_ASYNC_ENABLED=${SCALABILITY_ASYNC_ENABLED}
+    ...    --variable    SCALABILITY_BASELINE_ENABLED=${SCALABILITY_BASELINE_ENABLED}
+    ...    --variable    SCALABILITY_BASELINE_SYNC_RETRIES=${SCALABILITY_BASELINE_SYNC_RETRIES}
+    ...    --variable    SCALABILITY_BASELINE_SYNC_RETRY_INTERVAL=${SCALABILITY_BASELINE_SYNC_RETRY_INTERVAL}
+    ...    --variable    SCALABILITY_BASELINE_ASYNC_TIMEOUT=${SCALABILITY_BASELINE_ASYNC_TIMEOUT}
+    ...    --variable    SCALABILITY_BASELINE_ASYNC_POLL_INTERVAL=${SCALABILITY_BASELINE_ASYNC_POLL_INTERVAL}
+    ...    --variable    SCALABILITY_ASYNC_WARMUP_ENABLED=${SCALABILITY_ASYNC_WARMUP_ENABLED}
+    ...    --variable    SCALABILITY_ASYNC_WARMUP_JOBS=${SCALABILITY_ASYNC_WARMUP_JOBS}
+    ...    --variable    SCALABILITY_ASYNC_WARMUP_SUBMIT_INTERVAL=${SCALABILITY_ASYNC_WARMUP_SUBMIT_INTERVAL}
+    ...    --variable    SCALABILITY_CLEAN_JOBS=${SCALABILITY_CLEAN_JOBS}
+    ...    --variable    SCALABILITY_CLEAN_SERVICE=${SCALABILITY_CLEAN_SERVICE}
+    ...    --variable    LOCUST_WAIT_MIN=${LOCUST_WAIT_MIN}
+    ...    --variable    LOCUST_WAIT_MAX=${LOCUST_WAIT_MAX}
+    ${result}=    Run Process    @{command}    stdout=True    stderr=True    cwd=${CURDIR}
+    Log    ${result.stdout}
+    Log    ${result.stderr}
+    Should Be Equal As Integers    ${result.rc}    0
+    Log To Console    Run configuration saved to: ${config_path}
+
+Collect Scalability Results
+    [Documentation]    Generate JSON and Markdown summaries for the Locust step using OSCAR Manager API.
+    [Arguments]    ${mode}    ${users}
+    ${output_prefix}=    Get Scalability Output Prefix    ${mode}    ${users}
+    ${summary_json}=    Set Variable    ${output_prefix}_summary.json
+    ${summary_md}=      Set Variable    ${output_prefix}_summary.md
+    ${command}=    Create List    python3    ${COLLECTOR}
+    ...    --endpoint    ${OSCAR_ENDPOINT}
+    ...    --service    ${SCALABILITY_SERVICE_NAME}
+    ...    --mode    ${mode}
+    ...    --locust-prefix    ${output_prefix}
+    ...    --output    ${summary_json}
+    ...    --markdown    ${summary_md}
+    ...    --ssl-verify    ${SSL_VERIFY}
+    ${result}=    Run Process    @{command}    stdout=True    stderr=True    cwd=${CURDIR}
+    Log    ${result.stdout}
+    Log    ${result.stderr}
+    Should Be Equal As Integers    ${result.rc}    0
+    Log    Scalability summary written to ${summary_json} and ${summary_md}
+    ${summary}=    Evaluate    json.load(open(r'''${summary_json}''', encoding="utf-8"))    json
+    ${totals}=    Evaluate    $summary.get("locust", {}).get("totals", {})
+    ${request_count}=    Evaluate    int($totals.get("request_count", 0) or 0)
+    ${failure_count}=    Evaluate    int($totals.get("failure_count", 0) or 0)
+    ${failure_rate}=    Evaluate    (100.0 * $failure_count / $request_count) if $request_count else 0.0
+    ${failure_rate_text}=    Evaluate    f"{float($failure_rate):.2f}"
+    Log To Console    OSCAR scalability result: mode=${mode}, users=${users}, requests=${request_count}, failures=${failure_count}, failure_rate=${failure_rate_text}%; summary=${summary_json}
+    IF    ${failure_count} > 0
+        Log To Console    WARNING: Locust recorded ${failure_count} failed HTTP requests for mode=${mode}, users=${users}. The Robot test keeps running so the failure profile is preserved in the experiment artifact.
+    END
+
+Build Scalability Experiment Artifact
+    [Documentation]    Build a portable experiment JSON and publish the D3 static viewer.
+    ${command}=    Create List    python3    ${EXPERIMENT_BUILDER}
+    ...    --experiment-dir    ${SCALABILITY_EXPERIMENT_DIR}
+    ...    --output-root    ${SCALABILITY_OUTPUT_DIR}
+    ...    --service    ${SCALABILITY_SERVICE_NAME}
+    ...    --viewer-src    ${SCALABILITY_VIEWER_DIR}
+    ...    --endpoint    ${OSCAR_ENDPOINT}
+    ${result}=    Run Process    @{command}    stdout=True    stderr=True    cwd=${CURDIR}
+    Log    ${result.stdout}
+    Log    ${result.stderr}
+    Should Be Equal As Integers    ${result.rc}    0
+    ${artifact_info}=    Evaluate    json.loads($result.stdout)    json
+    Log To Console    OSCAR scalability experiment artifact: ${artifact_info["experiment"]}
+    Log To Console    OSCAR scalability viewer: ${artifact_info["viewer"]}
+    Log To Console    OSCAR scalability published viewer copy: ${artifact_info["published_viewer"]}
+
+Prepare Simple Test Service File
+    [Documentation]    Generate the simple-test service definition for this run.
+    ${yaml_content}=    Get File    ${SCALABILITY_SERVICE_FILE}
+    ${service_content}=    Set Service File VO    ${yaml_content}
+    ${modified_content}=    Set Variable    ${service_content}[functions][oscar][0][oscar-cluster]
+    ${script}=    Get File    ${SCALABILITY_SERVICE_SCRIPT}
+    Set To Dictionary    ${modified_content}    script=${script}
+    Set To Dictionary    ${modified_content}    name=${SCALABILITY_SERVICE_NAME}
+    Set To Dictionary    ${modified_content}    cpu=${SCALABILITY_SERVICE_CPU}
+    Set To Dictionary    ${modified_content}    memory=${SCALABILITY_SERVICE_MEMORY}
+    Set To Dictionary    ${modified_content}    isolation_level=SERVICE
+    ${input_entries}=    Get From Dictionary    ${modified_content}    input
+    ${first_input}=    Get From List    ${input_entries}    0
+    Set To Dictionary    ${first_input}    path=${SCALABILITY_SERVICE_NAME}/input
+    ${output_entries}=    Get From Dictionary    ${modified_content}    output
+    ${first_output}=    Get From List    ${output_entries}    0
+    Set To Dictionary    ${first_output}    path=${SCALABILITY_SERVICE_NAME}/output
+    ${service_content_json}=    Evaluate    json.dumps(${modified_content})    json
+    Create File    ${SCALABILITY_SERVICE_JSON}    ${service_content_json}
+
+Wait For Scalability Service Ready
+    [Documentation]    Poll service status until it is ready.
+    Wait Until Keyword Succeeds    240s    5s    Scalability Service Should Be Ready
+
+Scalability Service Should Be Ready
+    ${response}=    GET With Defaults    url=${OSCAR_ENDPOINT}/system/services/${SCALABILITY_SERVICE_NAME}    expected_status=200
+    ${payload}=    Evaluate    json.loads($response.content)    json
+    ${status}=    Evaluate    (lambda d: d.get('status') if not isinstance(d.get('status'), dict) else d['status'].get('state') or d['status'].get('phase') or d['status'].get('condition'))(${payload})    json
+    ${ready}=    Evaluate    str(${status}).lower() in ("ready","running","available","succeeded") or bool(${payload}.get('ready')) or bool(${payload}.get('token'))    json
+    Should Be True    ${ready}    Service not ready yet (status=${status})
+
+Delete Scalability Jobs
+    ${response}=    DELETE With Defaults    url=${OSCAR_ENDPOINT}/system/logs/${SCALABILITY_SERVICE_NAME}?all=true    expected_status=ANY
+    Log    Delete jobs response: ${response.status_code}
+
+Delete Scalability Service
+    ${response}=    DELETE With Defaults    url=${OSCAR_ENDPOINT}/system/services/${SCALABILITY_SERVICE_NAME}    expected_status=ANY
+    Log    Delete service response: ${response.status_code}
+
+Get Scalability Output Prefix
+    [Arguments]    ${mode}    ${users}
+    ${prefix}=    Catenate    SEPARATOR=/    ${SCALABILITY_EXPERIMENT_DIR}    ${SCALABILITY_SERVICE_NAME}-${mode}-${users}u
+    RETURN    ${prefix}
+
+GET With Defaults
+    [Arguments]    ${url}    ${expected_status}=200    ${headers}=${HEADERS}
+    ${headers}=    Run Keyword If    '${LOCAL_TESTING}'=='True'    Set Variable    ${HEADERS_OSCAR}    ELSE    Set Variable    ${headers}
+    ${response}=    GET    url=${url}    expected_status=${expected_status}    verify=${SSL_VERIFY}    headers=&{headers}
+    RETURN    ${response}
+
+POST With Defaults
+    [Arguments]    ${url}    ${data}    ${headers}=${HEADERS}
+    ${headers}=    Run Keyword If    '${LOCAL_TESTING}'=='True'    Set Variable    ${HEADERS_OSCAR}    ELSE    Set Variable    ${headers}
+    ${response}=    POST    url=${url}    data=${data}    expected_status=ANY    verify=${SSL_VERIFY}    headers=&{headers}
+    RETURN    ${response}
+
+DELETE With Defaults
+    [Arguments]    ${url}    ${expected_status}=204    ${headers}=${HEADERS}
+    ${headers}=    Run Keyword If    '${LOCAL_TESTING}'=='True'    Set Variable    ${HEADERS_OSCAR}    ELSE    Set Variable    ${headers}
+    ${response}=    DELETE    url=${url}    expected_status=${expected_status}    verify=${SSL_VERIFY}    headers=&{headers}
+    RETURN    ${response}

--- a/tests/scalability/src/build_experiment.py
+++ b/tests/scalability/src/build_experiment.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python3
+"""Build a portable OSCAR scalability experiment artifact and publish the viewer."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from capture_cluster_status import cluster_resources, prune_empty
+
+OSCAR_HUB_BASE_URL = "https://github.com/grycap/oscar-hub/tree/main/crates"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--experiment-dir", required=True)
+    parser.add_argument("--output-root", required=True)
+    parser.add_argument("--service", required=True)
+    parser.add_argument("--viewer-src", required=True)
+    parser.add_argument("--endpoint", required=True)
+    return parser.parse_args()
+
+
+def load_json(path: Path) -> Dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json(path: Path, payload: Dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def as_int(value: Any) -> int:
+    try:
+        return int(float(value or 0))
+    except (TypeError, ValueError):
+        return 0
+
+
+def as_float(value: Any) -> Optional[float]:
+    if value in {None, "", "N/A"}:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def first_request_row(rows: List[Dict[str, Any]]) -> Dict[str, Any]:
+    for row in rows:
+        if row.get("Name") != "Aggregated":
+            return row
+    return rows[0] if rows else {}
+
+
+def metric_from_locust(summary: Dict[str, Any]) -> Dict[str, Any]:
+    locust = summary.get("locust", {})
+    totals = locust.get("totals", {})
+    row = first_request_row(locust.get("rows", []))
+    request_count = as_int(totals.get("request_count"))
+    failure_count = as_int(totals.get("failure_count"))
+    return {
+        "requests": request_count,
+        "failures": failure_count,
+        "successes": max(request_count - failure_count, 0),
+        "failure_rate": failure_count / request_count if request_count else 0.0,
+        "requests_per_second": as_float(row.get("Requests/s")),
+        "failures_per_second": as_float(row.get("Failures/s")),
+        "latency_ms": {
+            "avg": as_float(row.get("Average Response Time")),
+            "min": as_float(row.get("Min Response Time")),
+            "max": as_float(row.get("Max Response Time")),
+            "p50": as_float(row.get("50%")),
+            "p95": as_float(row.get("95%")),
+            "p99": as_float(row.get("99%")),
+        },
+        "failure_details": locust.get("failures", []),
+    }
+
+
+def artifact_paths(experiment_dir: Path, service: str, mode: str, users: int) -> Dict[str, str]:
+    prefix = experiment_dir / f"{service}-{mode}-{users}u"
+    candidates = {
+        "summary_json": Path(f"{prefix}_summary.json"),
+        "summary_markdown": Path(f"{prefix}_summary.md"),
+        "locust_html": Path(f"{prefix}.html"),
+        "locust_stats_csv": Path(f"{prefix}_stats.csv"),
+        "locust_history_csv": Path(f"{prefix}_stats_history.csv"),
+        "locust_failures_csv": Path(f"{prefix}_failures.csv"),
+        "locust_exceptions_csv": Path(f"{prefix}_exceptions.csv"),
+        "locust_json": Path(f"{prefix}_locust.json"),
+    }
+    return {name: str(path.relative_to(experiment_dir)) for name, path in candidates.items() if path.exists()}
+
+
+def build_step(experiment_dir: Path, service: str, mode: str, users: int, summary: Dict[str, Any]) -> Dict[str, Any]:
+    step: Dict[str, Any] = {
+        "mode": mode,
+        "users": users,
+        "locust": metric_from_locust(summary),
+        "artifacts": artifact_paths(experiment_dir, service, mode, users),
+    }
+    if "jobs" in summary:
+        jobs = summary["jobs"]
+        step["jobs"] = {
+            "total": jobs.get("total", 0),
+            "terminal": jobs.get("terminal", 0),
+            "unfinished": jobs.get("unfinished", 0),
+            "status_counts": jobs.get("status_counts", {}),
+            "completion_seconds": jobs.get("completion_seconds", {}),
+            "pre_run_seconds": jobs.get("pre_run_seconds", {}),
+            "run_seconds": jobs.get("run_seconds", {}),
+            "timings": jobs.get("timings", []),
+        }
+    return step
+
+
+def discover_steps(experiment_dir: Path, service: str) -> List[Dict[str, Any]]:
+    steps: List[Dict[str, Any]] = []
+    for mode in ("sync", "async"):
+        for path in experiment_dir.glob(f"{service}-{mode}-*u_summary.json"):
+            users_text = path.name.removeprefix(f"{service}-{mode}-").removesuffix("u_summary.json")
+            try:
+                users = int(users_text)
+            except ValueError:
+                continue
+            steps.append(build_step(experiment_dir, service, mode, users, load_json(path)))
+    return sorted(steps, key=lambda item: (item["mode"], item["users"]))
+
+
+def latest_mtime(paths: List[Path]) -> float:
+    existing = [path.stat().st_mtime for path in paths if path.exists()]
+    return max(existing) if existing else datetime.now().timestamp()
+
+
+def service_base_name(service: str) -> str:
+    return service.rsplit("-", 1)[0] if "-" in service else service
+
+
+def hub_url(service_base: str) -> Optional[str]:
+    if service_base == "simple-test":
+        return f"{OSCAR_HUB_BASE_URL}/{service_base}"
+    return None
+
+
+def invocation_resources(steps: List[Dict[str, Any]], service_config: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
+    resources = {}
+    for mode in sorted({step["mode"] for step in steps}):
+        resources[mode] = {
+            "cpu_cores": service_config.get("cpu"),
+            "memory_mib": service_config.get("memory_mib"),
+            "source": "OSCAR service resource request per invocation",
+        }
+    return resources
+
+
+def build_experiment(experiment_dir: Path, service: str, endpoint: str) -> Dict[str, Any]:
+    plan_path = experiment_dir / "quota-plan.json"
+    cluster_status_path = experiment_dir / "cluster-status.json"
+    baseline_path = experiment_dir / "baseline.json"
+    async_warmup_path = experiment_dir / "async-warmup.json"
+    run_configuration_path = experiment_dir / "run-configuration.json"
+    plan = load_json(plan_path) if plan_path.exists() else {}
+    cluster_status = load_json(cluster_status_path) if cluster_status_path.exists() else {}
+    baseline = load_json(baseline_path) if baseline_path.exists() else {}
+    async_warmup = load_json(async_warmup_path) if async_warmup_path.exists() else {}
+    run_configuration = load_json(run_configuration_path) if run_configuration_path.exists() else {}
+    if cluster_status and not cluster_status.get("resources"):
+        cluster_status["resources"] = prune_empty(cluster_resources(cluster_status.get("payload")))
+    steps = discover_steps(experiment_dir, service)
+    if not steps:
+        raise SystemExit(f"No summary files found for service {service!r} in {experiment_dir}")
+
+    mtimes = [experiment_dir / artifact for step in steps for artifact in step.get("artifacts", {}).values()]
+    mtimes.extend(
+        path
+        for path in (plan_path, cluster_status_path, baseline_path, async_warmup_path, run_configuration_path)
+        if path.exists()
+    )
+    created_at = datetime.fromtimestamp(latest_mtime(mtimes)).astimezone().isoformat(timespec="seconds")
+    service_config = plan.get("service", {})
+    service_base = service_base_name(service)
+    quota = plan.get("quota", {})
+    limits = plan.get("limits", {})
+
+    return {
+        "schema_version": "1.4",
+        "experiment_id": service,
+        "created_at": created_at,
+        "platform": {
+            "endpoint": endpoint,
+            "quota_source": plan.get("quota_path"),
+            "quota_available": plan.get("quota_available", False),
+            "quota": {
+                "cpu_available_cores": quota.get("cpu_available"),
+                "memory_available_mib": quota.get("memory_available_mib"),
+                "safe_parallel_capacity": limits.get("safe_parallel"),
+                "cpu_parallel_capacity": limits.get("cpu_parallel"),
+                "memory_parallel_capacity": limits.get("memory_parallel"),
+            },
+            "cluster_status": cluster_status,
+            "cluster_resources": cluster_status.get("resources", {}),
+        },
+        "service": {
+            "name": service,
+            "base": service_base,
+            "hub": {
+                "name": service_base,
+                "url": hub_url(service_base),
+            },
+            "cpu": service_config.get("cpu"),
+            "memory_mib": service_config.get("memory_mib"),
+            "resources": {
+                "cpu_cores": service_config.get("cpu"),
+                "memory_mib": service_config.get("memory_mib"),
+            },
+            "invocation_resources": invocation_resources(steps, service_config),
+        },
+        "load_plan": {
+            "requested_users": plan.get("requested_users", sorted({step["users"] for step in steps})),
+            "effective_users": plan.get("effective_users", sorted({step["users"] for step in steps})),
+            "quota_mode": plan.get("mode"),
+        },
+        "quota_plan": plan,
+        "cluster_status": cluster_status,
+        "baseline": baseline,
+        "async_warmup": async_warmup,
+        "run_configuration": run_configuration,
+        "steps": steps,
+        "artifacts": {
+            "quota_plan": str(plan_path.relative_to(experiment_dir)) if plan_path.exists() else None,
+            "cluster_status": str(cluster_status_path.relative_to(experiment_dir)) if cluster_status_path.exists() else None,
+            "baseline": str(baseline_path.relative_to(experiment_dir)) if baseline_path.exists() else None,
+            "async_warmup": str(async_warmup_path.relative_to(experiment_dir)) if async_warmup_path.exists() else None,
+            "run_configuration": str(run_configuration_path.relative_to(experiment_dir)) if run_configuration_path.exists() else None,
+            "experiment": "experiment.json",
+        },
+    }
+
+
+def update_index(experiments_dir: Path, experiment: Dict[str, Any]) -> Dict[str, Any]:
+    index_path = experiments_dir / "index.json"
+    if index_path.exists():
+        index = load_json(index_path)
+    else:
+        index = {"schema_version": "1.0", "experiments": []}
+
+    entry = {
+        "id": experiment["experiment_id"],
+        "file": f"{experiment['experiment_id']}/experiment.json",
+        "directory": experiment["experiment_id"],
+        "created_at": experiment["created_at"],
+        "service": experiment["service"]["name"],
+        "endpoint": experiment["platform"].get("endpoint"),
+        "users": experiment["load_plan"]["effective_users"],
+        "quota_safe_parallel": experiment["platform"]["quota"].get("safe_parallel_capacity"),
+    }
+    existing = [item for item in index.get("experiments", []) if item.get("id") != entry["id"]]
+    existing.append(entry)
+    index["experiments"] = sorted(existing, key=lambda item: item.get("created_at", ""), reverse=True)
+    write_json(index_path, index)
+    return index
+
+
+def copy_viewer(viewer_src: Path, viewer_dst: Path) -> None:
+    if viewer_dst.exists():
+        shutil.rmtree(viewer_dst)
+    shutil.copytree(viewer_src, viewer_dst)
+
+
+def publish_viewer_data(viewer_dir: Path, index: Dict[str, Any], experiments_dir: Path) -> None:
+    experiments = []
+    for entry in index.get("experiments", []):
+        path = experiments_dir / entry["file"]
+        if path.exists():
+            experiments.append(load_json(path))
+
+    data_dir = viewer_dir / "data"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "schema_version": "1.0",
+        "index": index,
+        "experiments": experiments,
+    }
+    content = "window.OSCAR_SCALABILITY_DATA = " + json.dumps(payload, indent=2, sort_keys=True) + ";\n"
+    (data_dir / "experiments.js").write_text(content, encoding="utf-8")
+
+
+def main() -> int:
+    args = parse_args()
+    experiment_dir = Path(args.experiment_dir)
+    output_root = Path(args.output_root)
+    viewer_src = Path(args.viewer_src)
+    experiments_dir = output_root / "experiments"
+    viewer_dst = output_root / "viewer"
+
+    experiment = build_experiment(experiment_dir, args.service, args.endpoint)
+    experiment_path = experiment_dir / "experiment.json"
+    write_json(experiment_path, experiment)
+    index = update_index(experiments_dir, experiment)
+    copy_viewer(viewer_src, viewer_dst)
+    publish_viewer_data(viewer_dst, index, experiments_dir)
+
+    print(
+        json.dumps(
+            {
+                "experiment": str(experiment_path),
+                "viewer": str(viewer_src / "index.html"),
+                "published_viewer": str(viewer_dst / "index.html"),
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scalability/src/capture_cluster_status.py
+++ b/tests/scalability/src/capture_cluster_status.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Capture an OSCAR cluster status snapshot for a scalability experiment."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import ssl
+import sys
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--endpoint", required=True)
+    parser.add_argument("--access-token", default=os.getenv("OSCAR_ACCESS_TOKEN", ""))
+    parser.add_argument("--authorization-header", default=os.getenv("OSCAR_AUTHORIZATION_HEADER", ""))
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--ssl-verify", default=os.getenv("SSL_VERIFY", "true"))
+    return parser.parse_args()
+
+
+def truthy(value: str) -> bool:
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def ssl_context(ssl_verify: str) -> Optional[ssl.SSLContext]:
+    if truthy(ssl_verify):
+        return None
+    return ssl._create_unverified_context()  # nosec B323: test tooling supports self-signed clusters.
+
+
+def decode_payload(raw: str) -> Any:
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return raw
+
+
+def to_float(value: Any) -> Optional[float]:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def cpu_to_cores(value: Any) -> Optional[float]:
+    amount = to_float(value)
+    if amount is None:
+        return None
+    # OSCAR status currently reports these values in millicores despite the field name.
+    return amount / 1000 if amount > 128 else amount
+
+
+def bytes_to_mib(value: Any) -> Optional[float]:
+    amount = to_float(value)
+    if amount is None:
+        return None
+    return amount / (1024 * 1024)
+
+
+def sum_values(values: List[Optional[float]]) -> Optional[float]:
+    present = [value for value in values if value is not None]
+    if not present:
+        return None
+    return sum(present)
+
+
+def cluster_resources(payload: Any) -> Dict[str, Any]:
+    if not isinstance(payload, dict):
+        return {}
+
+    cluster = payload.get("cluster", {})
+    if not isinstance(cluster, dict):
+        return {}
+
+    metrics = cluster.get("metrics", {}) if isinstance(cluster.get("metrics"), dict) else {}
+    cpu_metrics = metrics.get("cpu", {}) if isinstance(metrics.get("cpu"), dict) else {}
+    memory_metrics = metrics.get("memory", {}) if isinstance(metrics.get("memory"), dict) else {}
+    gpu_metrics = metrics.get("gpu", {}) if isinstance(metrics.get("gpu"), dict) else {}
+    nodes = cluster.get("nodes", []) if isinstance(cluster.get("nodes"), list) else []
+
+    node_cpu_capacity = []
+    node_cpu_usage = []
+    node_memory_capacity = []
+    node_memory_usage = []
+    for node in nodes:
+        if not isinstance(node, dict):
+            continue
+        cpu = node.get("cpu", {}) if isinstance(node.get("cpu"), dict) else {}
+        memory = node.get("memory", {}) if isinstance(node.get("memory"), dict) else {}
+        node_cpu_capacity.append(cpu_to_cores(cpu.get("capacity_cores")))
+        node_cpu_usage.append(cpu_to_cores(cpu.get("usage_cores")))
+        node_memory_capacity.append(bytes_to_mib(memory.get("capacity_bytes")))
+        node_memory_usage.append(bytes_to_mib(memory.get("usage_bytes")))
+
+    return {
+        "nodes_count": cluster.get("nodes_count") if cluster.get("nodes_count") is not None else len(nodes),
+        "cpu": {
+            "total_free_cores": cpu_to_cores(cpu_metrics.get("total_free_cores")),
+            "max_free_on_node_cores": cpu_to_cores(cpu_metrics.get("max_free_on_node_cores")),
+            "total_capacity_cores": sum_values(node_cpu_capacity),
+            "total_used_cores": sum_values(node_cpu_usage),
+        },
+        "memory": {
+            "total_free_mib": bytes_to_mib(memory_metrics.get("total_free_bytes")),
+            "max_free_on_node_mib": bytes_to_mib(memory_metrics.get("max_free_on_node_bytes")),
+            "total_capacity_mib": sum_values(node_memory_capacity),
+            "total_used_mib": sum_values(node_memory_usage),
+        },
+        "gpu": {
+            "total": gpu_metrics.get("total_gpu"),
+        },
+    }
+
+
+def prune_empty(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: pruned for key, item in value.items() if (pruned := prune_empty(item)) not in ({}, [], None)}
+    if isinstance(value, list):
+        return [pruned for item in value if (pruned := prune_empty(item)) not in ({}, [], None)]
+    return value
+
+
+def capture_status(args: argparse.Namespace) -> Dict[str, Any]:
+    url = f"{args.endpoint.rstrip('/')}/system/status"
+    request = urllib.request.Request(url)
+    request.add_header("Accept", "application/json")
+    authorization = auth_header(args)
+    if authorization:
+        request.add_header("Authorization", authorization)
+
+    snapshot: Dict[str, Any] = {
+        "captured_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "endpoint": url,
+        "available": False,
+        "status_code": None,
+        "payload": None,
+    }
+
+    try:
+        with urllib.request.urlopen(request, context=ssl_context(args.ssl_verify), timeout=60) as response:
+            body = response.read().decode("utf-8", errors="replace")
+            snapshot["available"] = 200 <= response.status < 300
+            snapshot["status_code"] = response.status
+            snapshot["payload"] = decode_payload(body)
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")
+        snapshot["status_code"] = exc.code
+        snapshot["payload"] = decode_payload(body)
+        snapshot["error"] = f"HTTP {exc.code}"
+    except Exception as exc:  # noqa: BLE001 - status capture is informative and should not block the test.
+        snapshot["error"] = str(exc)
+
+    snapshot["resources"] = prune_empty(cluster_resources(snapshot.get("payload")))
+    return snapshot
+
+
+def auth_header(args: argparse.Namespace) -> str:
+    if args.authorization_header:
+        return args.authorization_header
+    if args.access_token:
+        return f"Bearer {args.access_token}"
+    return ""
+
+
+def main() -> int:
+    args = parse_args()
+    snapshot = capture_status(args)
+    output = Path(args.output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(snapshot, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps(snapshot, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scalability/src/collect_scalability_results.py
+++ b/tests/scalability/src/collect_scalability_results.py
@@ -1,0 +1,351 @@
+#!/usr/bin/env python3
+"""Collect OSCAR scalability results after a Locust step."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import ssl
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections import Counter
+from datetime import datetime
+from pathlib import Path
+from statistics import mean
+from typing import Any, Dict, Iterable, List, Optional
+
+
+TERMINAL_STATUSES = {"Succeeded", "Failed"}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--endpoint", required=True)
+    parser.add_argument("--service", required=True)
+    parser.add_argument("--mode", required=True, choices=["sync", "async", "mixed"])
+    parser.add_argument("--locust-prefix", required=True)
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--markdown", required=True)
+    parser.add_argument("--ssl-verify", default=os.getenv("SSL_VERIFY", "true"))
+    parser.add_argument("--access-token", default=os.getenv("OSCAR_ACCESS_TOKEN", ""))
+    parser.add_argument("--authorization-header", default=os.getenv("OSCAR_AUTHORIZATION_HEADER", ""))
+    return parser.parse_args()
+
+
+def truthy(value: str) -> bool:
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def auth_header(args: argparse.Namespace) -> str:
+    if args.authorization_header:
+        return args.authorization_header
+    if args.access_token:
+        return f"Bearer {args.access_token}"
+    return ""
+
+
+def request_json(args: argparse.Namespace, path: str, params: Optional[Dict[str, str]] = None) -> Dict[str, Any]:
+    endpoint = args.endpoint.rstrip("/")
+    query = f"?{urllib.parse.urlencode(params)}" if params else ""
+    request = urllib.request.Request(f"{endpoint}{path}{query}")
+    request.add_header("Accept", "application/json")
+    authorization = auth_header(args)
+    if authorization:
+        request.add_header("Authorization", authorization)
+
+    context = None
+    if not truthy(args.ssl_verify):
+        context = ssl._create_unverified_context()  # nosec B323: test tooling supports self-signed clusters.
+
+    try:
+        with urllib.request.urlopen(request, context=context, timeout=60) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"GET {path} failed with {exc.code}: {body}") from exc
+
+
+def collect_jobs(args: argparse.Namespace) -> Dict[str, Any]:
+    all_jobs: Dict[str, Dict[str, Any]] = {}
+    page = ""
+    while True:
+        params = {"page": page} if page else None
+        payload = request_json(args, f"/system/logs/{urllib.parse.quote(args.service)}", params=params)
+        all_jobs.update(payload.get("jobs", {}))
+        page = payload.get("next_page") or ""
+        if not page:
+            break
+
+    statuses = Counter(job.get("status", "Unknown") for job in all_jobs.values())
+    timings = [_job_timings(name, job) for name, job in all_jobs.items()]
+    completion_times = [item["completion_seconds"] for item in timings if item.get("completion_seconds") is not None]
+    pre_run_times = [item["pre_run_seconds"] for item in timings if item.get("pre_run_seconds") is not None]
+    run_times = [item["run_seconds"] for item in timings if item.get("run_seconds") is not None]
+
+    return {
+        "total": len(all_jobs),
+        "status_counts": dict(statuses),
+        "terminal": sum(count for status, count in statuses.items() if status in TERMINAL_STATUSES),
+        "unfinished": sum(count for status, count in statuses.items() if status not in TERMINAL_STATUSES),
+        "timings": timings,
+        "completion_seconds": _stats(completion_times),
+        "pre_run_seconds": _stats(pre_run_times),
+        "run_seconds": _stats(run_times),
+    }
+
+
+def _parse_time(value: Optional[str]) -> Optional[datetime]:
+    if not value:
+        return None
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def _seconds_between(start: Optional[datetime], end: Optional[datetime]) -> Optional[float]:
+    if not start or not end:
+        return None
+    return max((end - start).total_seconds(), 0.0)
+
+
+def _job_timings(name: str, job: Dict[str, Any]) -> Dict[str, Any]:
+    created = _parse_time(job.get("creation_time"))
+    started = _parse_time(job.get("start_time"))
+    finished = _parse_time(job.get("finish_time"))
+    return {
+        "name": name,
+        "status": job.get("status", "Unknown"),
+        "creation_time": job.get("creation_time"),
+        "start_time": job.get("start_time"),
+        "finish_time": job.get("finish_time"),
+        "pre_run_seconds": _seconds_between(created, started),
+        "run_seconds": _seconds_between(started, finished),
+        "completion_seconds": _seconds_between(created, finished),
+    }
+
+
+def _stats(values: Iterable[float]) -> Dict[str, Optional[float]]:
+    sorted_values = sorted(values)
+    if not sorted_values:
+        return {"count": 0, "avg": None, "min": None, "max": None, "p50": None, "p95": None, "p99": None}
+    return {
+        "count": len(sorted_values),
+        "avg": mean(sorted_values),
+        "min": sorted_values[0],
+        "max": sorted_values[-1],
+        "p50": _percentile(sorted_values, 50),
+        "p95": _percentile(sorted_values, 95),
+        "p99": _percentile(sorted_values, 99),
+    }
+
+
+def _percentile(sorted_values: List[float], percentile: int) -> float:
+    if len(sorted_values) == 1:
+        return sorted_values[0]
+    index = round((percentile / 100) * (len(sorted_values) - 1))
+    return sorted_values[index]
+
+
+def collect_locust_stats(prefix: str) -> Dict[str, Any]:
+    stats_file = Path(f"{prefix}_stats.csv")
+    json_file = Path(f"{prefix}_locust.json")
+    if not stats_file.exists():
+        return {"stats_file": str(stats_file), "rows": [], "error": "stats file not found"}
+
+    rows: List[Dict[str, Any]] = []
+    with stats_file.open(newline="", encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
+        for row in reader:
+            if row.get("Name") == "Aggregated":
+                continue
+            rows.append(row)
+
+    json_stats = collect_locust_json_stats(json_file)
+    totals = json_stats.get("totals") or _locust_totals(rows)
+    failures = json_stats.get("failures") or collect_locust_failures(prefix)
+
+    return {
+        "stats_file": str(stats_file),
+        "json_file": str(json_file),
+        "rows": rows,
+        "totals": totals,
+        "failures": failures,
+    }
+
+
+def collect_locust_json_stats(path: Path) -> Dict[str, Any]:
+    if not path.exists():
+        return {}
+
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if isinstance(payload, dict):
+        stats = payload.get("stats") or payload.get("requests") or []
+        errors = payload.get("errors") or []
+        total = payload.get("total")
+    elif isinstance(payload, list):
+        stats = payload
+        errors = []
+        total = None
+    else:
+        return {}
+
+    totals = _json_totals(stats, total)
+    failures = _json_failures(errors)
+    return {"totals": totals, "failures": failures}
+
+
+def _json_totals(stats: List[Dict[str, Any]], total: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    source = total or next(
+        (
+            item
+            for item in stats
+            if str(item.get("name", "")).lower() in {"aggregated", "total"}
+            or str(item.get("method", "")).lower() in {"aggregated", "total"}
+        ),
+        None,
+    )
+    if source is None:
+        source = {
+            "num_requests": sum(_int(item.get("num_requests")) for item in stats),
+            "num_failures": sum(_int(item.get("num_failures")) for item in stats),
+            "avg_content_length": None,
+        }
+
+    request_count = _int(source.get("num_requests") or source.get("request_count"))
+    failure_count = _int(source.get("num_failures") or source.get("failure_count"))
+    return {
+        "request_count": request_count,
+        "failure_count": failure_count,
+        "success_count": max(request_count - failure_count, 0),
+        "average_content_size": source.get("avg_content_length") or source.get("average_content_size"),
+    }
+
+
+def _json_failures(errors: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    failures: List[Dict[str, Any]] = []
+    for item in errors:
+        failures.append(
+            {
+                "method": item.get("method", ""),
+                "name": item.get("name", ""),
+                "error": item.get("error") or item.get("message") or "",
+                "occurrences": _int(item.get("occurrences") or item.get("count")),
+            }
+        )
+    return failures
+
+
+def collect_locust_failures(prefix: str) -> List[Dict[str, Any]]:
+    failures_file = Path(f"{prefix}_failures.csv")
+    if not failures_file.exists():
+        return []
+
+    failures: List[Dict[str, Any]] = []
+    with failures_file.open(newline="", encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
+        for row in reader:
+            if not any(row.values()):
+                continue
+            failures.append(
+                {
+                    "method": row.get("Method", ""),
+                    "name": row.get("Name", ""),
+                    "error": row.get("Error", ""),
+                    "occurrences": _int(row.get("Occurrences")),
+                }
+            )
+    return failures
+
+
+def _locust_totals(rows: List[Dict[str, str]]) -> Dict[str, Any]:
+    request_count = sum(_int(row.get("Request Count")) for row in rows)
+    failure_count = sum(_int(row.get("Failure Count")) for row in rows)
+    avg_sizes = [_float(row.get("Average Content Size")) for row in rows if row.get("Average Content Size")]
+    return {
+        "request_count": request_count,
+        "failure_count": failure_count,
+        "success_count": max(request_count - failure_count, 0),
+        "average_content_size": mean(avg_sizes) if avg_sizes else None,
+    }
+
+
+def _int(value: Optional[str]) -> int:
+    try:
+        return int(float(value or 0))
+    except ValueError:
+        return 0
+
+
+def _float(value: Optional[str]) -> float:
+    try:
+        return float(value or 0)
+    except ValueError:
+        return 0.0
+
+
+def write_markdown(summary: Dict[str, Any], path: Path) -> None:
+    locust_totals = summary["locust"].get("totals", {})
+    lines = [
+        f"# OSCAR scalability step: {summary['mode']}",
+        "",
+        f"- Service: `{summary['service']}`",
+        f"- Locust requests: {locust_totals.get('request_count', 0)}",
+        f"- Locust failures: {locust_totals.get('failure_count', 0)}",
+    ]
+    failures = summary["locust"].get("failures", [])
+    if failures:
+        lines.extend(["", "## Locust Failures", ""])
+        lines.extend(f"- {item['occurrences']} x `{item['method']} {item['name']}`: {item['error']}" for item in failures)
+    if summary.get("jobs"):
+        jobs = summary["jobs"]
+        lines.extend(
+            [
+                f"- Jobs visible through OSCAR Manager: {jobs['total']}",
+                f"- Terminal jobs: {jobs['terminal']}",
+                f"- Unfinished jobs: {jobs['unfinished']}",
+                f"- Job statuses: `{json.dumps(jobs['status_counts'], sort_keys=True)}`",
+                "",
+                "## Async End-To-End Timings",
+                "",
+                "| Metric | Count | Avg | P50 | P95 | P99 | Max |",
+                "| --- | ---: | ---: | ---: | ---: | ---: | ---: |",
+                _timing_row("Completion seconds", jobs["completion_seconds"]),
+                _timing_row("Pre-run seconds", jobs["pre_run_seconds"]),
+                _timing_row("Run seconds", jobs["run_seconds"]),
+            ]
+        )
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _timing_row(label: str, stats: Dict[str, Optional[float]]) -> str:
+    return (
+        f"| {label} | {stats['count']} | {_fmt(stats['avg'])} | {_fmt(stats['p50'])} | "
+        f"{_fmt(stats['p95'])} | {_fmt(stats['p99'])} | {_fmt(stats['max'])} |"
+    )
+
+
+def _fmt(value: Optional[float]) -> str:
+    return "-" if value is None else f"{value:.3f}"
+
+
+def main() -> int:
+    args = parse_args()
+    summary: Dict[str, Any] = {
+        "service": args.service,
+        "mode": args.mode,
+        "locust": collect_locust_stats(args.locust_prefix),
+    }
+    if args.mode in {"async", "mixed"}:
+        summary["jobs"] = collect_jobs(args)
+
+    output = Path(args.output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    write_markdown(summary, Path(args.markdown))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scalability/src/measure_baseline_invocations.py
+++ b/tests/scalability/src/measure_baseline_invocations.py
@@ -1,0 +1,368 @@
+#!/usr/bin/env python3
+"""Measure isolated OSCAR invocations before the Locust scalability steps."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import binascii
+import json
+import os
+import ssl
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Optional, Set, Tuple
+
+
+TERMINAL_STATUSES = {"Succeeded", "Failed"}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--endpoint", required=True)
+    parser.add_argument("--service", required=True)
+    parser.add_argument("--access-token", default=os.getenv("OSCAR_ACCESS_TOKEN", ""))
+    parser.add_argument("--authorization-header", default=os.getenv("OSCAR_AUTHORIZATION_HEADER", ""))
+    parser.add_argument(
+        "--invocation-authorization-header",
+        default=os.getenv("OSCAR_INVOCATION_AUTHORIZATION_HEADER", ""),
+    )
+    parser.add_argument("--payload-file", required=True)
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--ssl-verify", default=os.getenv("SSL_VERIFY", "true"))
+    parser.add_argument("--content-type", default="text/plain")
+    parser.add_argument("--base64-payload", default="true")
+    parser.add_argument("--unique-payload", default="true")
+    parser.add_argument("--sync-retries", type=int, default=15)
+    parser.add_argument("--sync-retry-interval", type=float, default=2.0)
+    parser.add_argument("--async-timeout", type=float, default=120.0)
+    parser.add_argument("--async-poll-interval", type=float, default=2.0)
+    return parser.parse_args()
+
+
+def truthy(value: str) -> bool:
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def ssl_context(ssl_verify: str) -> Optional[ssl.SSLContext]:
+    if truthy(ssl_verify):
+        return None
+    return ssl._create_unverified_context()  # nosec B323: test tooling supports self-signed clusters.
+
+
+def now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="milliseconds")
+
+
+def headers(args: argparse.Namespace) -> Dict[str, str]:
+    request_headers = {
+        "Accept": "text/plain, application/json",
+        "Content-Type": args.content_type,
+    }
+    authorization = invocation_auth_header(args)
+    if authorization:
+        request_headers["Authorization"] = authorization
+    return request_headers
+
+
+def manager_auth_header(args: argparse.Namespace) -> str:
+    if args.authorization_header:
+        return args.authorization_header
+    if args.access_token:
+        return f"Bearer {args.access_token}"
+    return ""
+
+
+def invocation_auth_header(args: argparse.Namespace) -> str:
+    if args.invocation_authorization_header:
+        return args.invocation_authorization_header
+    return manager_auth_header(args)
+
+
+def payload(args: argparse.Namespace, label: str) -> bytes:
+    text = Path(args.payload_file).read_text(encoding="utf-8")
+    if truthy(args.unique_payload):
+        text = f"{text.rstrip()}\nrequest_id={label}-{uuid.uuid4()}\n"
+    if truthy(args.base64_payload):
+        text = base64.b64encode(text.encode("utf-8")).decode("ascii")
+    return text.encode("utf-8")
+
+
+def decode_response_text(text: str) -> str:
+    try:
+        return base64.b64decode(text.strip(), validate=True).decode("utf-8", errors="replace")
+    except (binascii.Error, ValueError):
+        return text
+
+
+def post(args: argparse.Namespace, path: str, body: bytes) -> Tuple[int, str, float, Dict[str, str]]:
+    url = f"{args.endpoint.rstrip('/')}{path}"
+    request = urllib.request.Request(url, data=body, method="POST")
+    for key, value in headers(args).items():
+        request.add_header(key, value)
+
+    started = time.perf_counter()
+    try:
+        with urllib.request.urlopen(request, context=ssl_context(args.ssl_verify), timeout=120) as response:
+            response_body = response.read().decode("utf-8", errors="replace")
+            elapsed_ms = (time.perf_counter() - started) * 1000
+            return response.status, response_body, elapsed_ms, dict(response.headers.items())
+    except urllib.error.HTTPError as exc:
+        response_body = exc.read().decode("utf-8", errors="replace")
+        elapsed_ms = (time.perf_counter() - started) * 1000
+        return exc.code, response_body, elapsed_ms, dict(exc.headers.items())
+
+
+def request_json(args: argparse.Namespace, path: str, params: Optional[Dict[str, str]] = None) -> Dict[str, Any]:
+    endpoint = args.endpoint.rstrip("/")
+    query = f"?{urllib.parse.urlencode(params)}" if params else ""
+    request = urllib.request.Request(f"{endpoint}{path}{query}")
+    request.add_header("Accept", "application/json")
+    authorization = manager_auth_header(args)
+    if authorization:
+        request.add_header("Authorization", authorization)
+    with urllib.request.urlopen(request, context=ssl_context(args.ssl_verify), timeout=60) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def collect_jobs(args: argparse.Namespace) -> Dict[str, Dict[str, Any]]:
+    all_jobs: Dict[str, Dict[str, Any]] = {}
+    page = ""
+    while True:
+        params = {"page": page} if page else None
+        try:
+            payload_data = request_json(args, f"/system/logs/{urllib.parse.quote(args.service)}", params=params)
+        except urllib.error.HTTPError as exc:
+            if exc.code == 404:
+                return all_jobs
+            raise
+        all_jobs.update(payload_data.get("jobs", {}))
+        page = payload_data.get("next_page") or ""
+        if not page:
+            break
+    return all_jobs
+
+
+def parse_time(value: Optional[str]) -> Optional[datetime]:
+    if not value:
+        return None
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def seconds_between(start: Optional[datetime], end: Optional[datetime]) -> Optional[float]:
+    if not start or not end:
+        return None
+    return max((end - start).total_seconds(), 0.0)
+
+
+def job_timing(name: str, job: Dict[str, Any]) -> Dict[str, Any]:
+    created = parse_time(job.get("creation_time"))
+    started = parse_time(job.get("start_time"))
+    finished = parse_time(job.get("finish_time"))
+    return {
+        "name": name,
+        "status": job.get("status", "Unknown"),
+        "creation_time": job.get("creation_time"),
+        "start_time": job.get("start_time"),
+        "finish_time": job.get("finish_time"),
+        "pre_run_seconds": seconds_between(created, started),
+        "run_seconds": seconds_between(started, finished),
+        "completion_seconds": seconds_between(created, finished),
+    }
+
+
+def new_job_name(before: Set[str], jobs: Dict[str, Dict[str, Any]]) -> Optional[str]:
+    candidates = sorted(set(jobs) - before)
+    if candidates:
+        return candidates[-1]
+    return None
+
+
+def should_retry_sync(status: Optional[int]) -> bool:
+    return status in {502, 503, 504}
+
+
+def measure_sync(args: argparse.Namespace, label: str) -> Dict[str, Any]:
+    result: Dict[str, Any] = {
+        "label": label,
+        "started_at": now(),
+        "endpoint": f"{args.endpoint.rstrip('/')}/run/{args.service}",
+    }
+    started = time.perf_counter()
+    max_attempts = max(args.sync_retries, 0) + 1
+    retry_interval = max(args.sync_retry_interval, 0)
+    failures = []
+
+    for attempt in range(1, max_attempts + 1):
+        try:
+            status, response_body, elapsed_ms, response_headers = post(
+                args,
+                f"/run/{urllib.parse.quote(args.service)}",
+                payload(args, label),
+            )
+            decoded = decode_response_text(response_body)
+            finished_at = now()
+            result.update(
+                {
+                    "finished_at": finished_at,
+                    "latency_ms": elapsed_ms,
+                    "status_code": status,
+                    "ok": status == 200,
+                    "response_bytes": len(response_body.encode("utf-8")),
+                    "content_type": response_headers.get("Content-Type") or response_headers.get("content-type"),
+                    "validated_output": "Words:" in decoded and "Characters:" in decoded,
+                    "attempts": attempt,
+                    "total_elapsed_ms": (time.perf_counter() - started) * 1000,
+                }
+            )
+            if status == 200:
+                break
+
+            failure = {
+                "attempt": attempt,
+                "finished_at": finished_at,
+                "latency_ms": elapsed_ms,
+                "status_code": status,
+                "response_bytes": len(response_body.encode("utf-8")),
+                "retryable": should_retry_sync(status),
+            }
+            if response_body:
+                failure["error"] = response_body[:500]
+            failures.append(failure)
+            result["error"] = response_body[:500]
+
+            if not should_retry_sync(status) or attempt == max_attempts:
+                break
+        except Exception as exc:  # noqa: BLE001 - baseline should be reported, not hide partial data.
+            result.update(
+                {
+                    "finished_at": now(),
+                    "ok": False,
+                    "error": str(exc),
+                    "attempts": attempt,
+                    "total_elapsed_ms": (time.perf_counter() - started) * 1000,
+                }
+            )
+            failures.append(
+                {
+                    "attempt": attempt,
+                    "finished_at": result["finished_at"],
+                    "error": str(exc),
+                    "retryable": True,
+                }
+            )
+            if attempt == max_attempts:
+                break
+
+        time.sleep(retry_interval)
+
+    if failures:
+        result["retry_failures"] = failures
+    return result
+
+
+def wait_for_job(args: argparse.Namespace, before: Set[str], submitted_at: float) -> Dict[str, Any]:
+    deadline = submitted_at + args.async_timeout
+    selected_name: Optional[str] = None
+    last_job: Dict[str, Any] = {}
+    polls = 0
+
+    while time.monotonic() < deadline:
+        polls += 1
+        jobs = collect_jobs(args)
+        if selected_name is None:
+            selected_name = new_job_name(before, jobs)
+        if selected_name and selected_name in jobs:
+            last_job = jobs[selected_name]
+            if last_job.get("status") in TERMINAL_STATUSES:
+                timing = job_timing(selected_name, last_job)
+                timing.update({"ok": last_job.get("status") == "Succeeded", "polls": polls, "observed_at": now()})
+                return timing
+        time.sleep(args.async_poll_interval)
+
+    if selected_name and last_job:
+        timing = job_timing(selected_name, last_job)
+        timing.update({"ok": False, "polls": polls, "observed_at": now(), "timeout": True})
+        return timing
+    return {"ok": False, "polls": polls, "observed_at": now(), "timeout": True, "error": "new job was not observed"}
+
+
+def measure_async(args: argparse.Namespace, label: str) -> Dict[str, Any]:
+    result: Dict[str, Any] = {
+        "label": label,
+        "started_at": now(),
+        "endpoint": f"{args.endpoint.rstrip('/')}/job/{args.service}",
+    }
+    try:
+        before = set(collect_jobs(args))
+        monotonic_start = time.monotonic()
+        status, response_body, elapsed_ms, response_headers = post(args, f"/job/{urllib.parse.quote(args.service)}", payload(args, label))
+        result["submit"] = {
+            "finished_at": now(),
+            "latency_ms": elapsed_ms,
+            "status_code": status,
+            "ok": status == 201,
+            "response_bytes": len(response_body.encode("utf-8")),
+            "content_type": response_headers.get("Content-Type") or response_headers.get("content-type"),
+        }
+        if status != 201:
+            result["submit"]["error"] = response_body[:500]
+            result["ok"] = False
+            return result
+        result["job"] = wait_for_job(args, before, monotonic_start)
+        result["ok"] = bool(result["submit"]["ok"] and result["job"].get("ok"))
+    except Exception as exc:  # noqa: BLE001 - baseline should be reported, not hide partial data.
+        result.update({"ok": False, "error": str(exc)})
+    result["finished_at"] = now()
+    return result
+
+
+def measure(args: argparse.Namespace) -> Dict[str, Any]:
+    return {
+        "schema_version": "1.0",
+        "captured_at": now(),
+        "endpoint": args.endpoint.rstrip("/"),
+        "service": args.service,
+        "description": "Isolated invocation baseline measured before the Locust load steps.",
+        "caveats": [
+            "This is not a guaranteed node-level cold start.",
+            "The test measures the first invocation after OSCAR reports the service as ready.",
+            "Docker image cache state on Kubernetes nodes is not controlled by this test.",
+        ],
+        "config": {
+            "base64_payload": truthy(args.base64_payload),
+            "unique_payload": truthy(args.unique_payload),
+            "sync_retries": args.sync_retries,
+            "sync_retry_interval_seconds": args.sync_retry_interval,
+            "async_timeout_seconds": args.async_timeout,
+            "async_poll_interval_seconds": args.async_poll_interval,
+        },
+        "sync": {
+            "first_ready": measure_sync(args, "sync-first-ready"),
+            "warm": measure_sync(args, "sync-warm"),
+        },
+        "async": {
+            "first_ready": measure_async(args, "async-first-ready"),
+            "warm": measure_async(args, "async-warm"),
+        },
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    baseline = measure(args)
+    output = Path(args.output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(baseline, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps(baseline, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scalability/src/oscar_api.py
+++ b/tests/scalability/src/oscar_api.py
@@ -2,6 +2,7 @@
 Locust user definitions for stressing the OSCAR Manager API.
 
 Environment variables consumed:
+    OSCAR_AUTHORIZATION_HEADER -> Full Authorization header for authenticated endpoints.
     OSCAR_ACCESS_TOKEN -> Bearer token used for authenticated endpoints.
     OSCAR_SERVICE_NAME -> Target service name (defaults to robot-test-cowsay).
     LOCUST_WAIT_MIN    -> Minimum wait time between tasks (seconds, default 1).
@@ -16,8 +17,11 @@ from locust import HttpUser, between, task
 
 def _build_headers() -> Dict[str, str]:
     """Build common headers for API requests."""
+    authorization = os.getenv("OSCAR_AUTHORIZATION_HEADER", "").strip()
     access_token = os.getenv("OSCAR_ACCESS_TOKEN", "").strip()
-    if access_token:
+    if authorization:
+        pass
+    elif access_token:
         authorization = f"Bearer {access_token}"
     else:
         # Falling back to basic auth allows running in limited environments.

--- a/tests/scalability/src/oscar_invocations.py
+++ b/tests/scalability/src/oscar_invocations.py
@@ -1,0 +1,113 @@
+"""
+Locust user definitions for OSCAR service invocation scalability tests.
+
+Environment variables consumed:
+    OSCAR_SERVICE_NAME   -> Target service name.
+    OSCAR_INVOCATION_AUTHORIZATION_HEADER -> Full Authorization header for /run and /job.
+    OSCAR_AUTHORIZATION_HEADER -> Fallback Authorization header for /run and /job.
+    OSCAR_ACCESS_TOKEN   -> Fallback user bearer token used for /run and /job.
+    OSCAR_LOAD_MODE      -> sync, async, or mixed.
+    SCALABILITY_PAYLOAD  -> Request body sent to the service.
+    SCALABILITY_BASE64_PAYLOAD -> Base64-encode payload before sending.
+    LOCUST_WAIT_MIN      -> Minimum wait time between tasks.
+    LOCUST_WAIT_MAX      -> Maximum wait time between tasks.
+"""
+
+import base64
+import binascii
+import os
+import random
+import uuid
+from typing import Dict
+
+from locust import HttpUser, between, task
+
+
+def _build_headers() -> Dict[str, str]:
+    authorization = os.getenv("OSCAR_INVOCATION_AUTHORIZATION_HEADER", "").strip()
+    fallback_authorization = os.getenv("OSCAR_AUTHORIZATION_HEADER", "").strip()
+    access_token = os.getenv("OSCAR_ACCESS_TOKEN", "").strip()
+
+    headers: Dict[str, str] = {
+        "Accept": "text/plain, application/json",
+        "Content-Type": os.getenv("SCALABILITY_CONTENT_TYPE", "text/plain"),
+    }
+
+    if authorization:
+        headers["Authorization"] = authorization
+    elif fallback_authorization:
+        headers["Authorization"] = fallback_authorization
+    elif access_token:
+        headers["Authorization"] = f"Bearer {access_token}"
+
+    return headers
+
+
+HEADERS = _build_headers()
+SERVICE_NAME = os.getenv("OSCAR_SERVICE_NAME", "simple-test")
+LOAD_MODE = os.getenv("OSCAR_LOAD_MODE", "sync").strip().lower()
+PAYLOAD = os.getenv("SCALABILITY_PAYLOAD", "The quick brown fox jumped over the lazy dog")
+
+
+def _decoded_response_text(text: str) -> str:
+    try:
+        return base64.b64decode(text.strip(), validate=True).decode("utf-8", errors="replace")
+    except (binascii.Error, ValueError):
+        return text
+
+
+class OscarInvocationUser(HttpUser):
+    """Locust user invoking an OSCAR service through /run and/or /job."""
+
+    wait_time = between(
+        float(os.getenv("LOCUST_WAIT_MIN", "0")),
+        float(os.getenv("LOCUST_WAIT_MAX", "0")),
+    )
+
+    @task
+    def invoke_service(self) -> None:
+        mode = LOAD_MODE
+        if mode == "mixed":
+            sync_weight = int(os.getenv("OSCAR_SYNC_WEIGHT", "1"))
+            async_weight = int(os.getenv("OSCAR_ASYNC_WEIGHT", "1"))
+            population = (["sync"] * sync_weight) + (["async"] * async_weight)
+            mode = random.choice(population)
+
+        if mode == "async":
+            self._invoke_async()
+        else:
+            self._invoke_sync()
+
+    def _payload(self) -> str:
+        payload = PAYLOAD
+        if os.getenv("SCALABILITY_UNIQUE_PAYLOAD", "true").lower() in {"1", "true", "yes"}:
+            payload = f"{payload}\nrequest_id={uuid.uuid4()}"
+        if os.getenv("SCALABILITY_BASE64_PAYLOAD", "true").lower() in {"1", "true", "yes"}:
+            return base64.b64encode(payload.encode("utf-8")).decode("ascii")
+        return payload
+
+    def _invoke_sync(self) -> None:
+        with self.client.post(
+            f"/run/{SERVICE_NAME}",
+            data=self._payload(),
+            headers=HEADERS,
+            name="POST /run/:service",
+            catch_response=True,
+        ) as response:
+            if response.status_code != 200:
+                response.failure(f"expected 200, got {response.status_code}: {response.text[:200]}")
+            else:
+                decoded_text = _decoded_response_text(response.text)
+                if "Words:" not in decoded_text and "Characters:" not in decoded_text:
+                    response.failure("sync response does not contain simple-test analysis output")
+
+    def _invoke_async(self) -> None:
+        with self.client.post(
+            f"/job/{SERVICE_NAME}",
+            data=self._payload(),
+            headers=HEADERS,
+            name="POST /job/:service",
+            catch_response=True,
+        ) as response:
+            if response.status_code != 201:
+                response.failure(f"expected 201, got {response.status_code}: {response.text[:200]}")

--- a/tests/scalability/src/plan_scalability_load.py
+++ b/tests/scalability/src/plan_scalability_load.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""Plan OSCAR scalability load steps from the user's quota."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import re
+import ssl
+import sys
+import time
+import urllib.error
+import urllib.request
+from typing import Any, Dict, List, Optional
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--endpoint", required=True)
+    parser.add_argument("--access-token", default=os.getenv("OSCAR_ACCESS_TOKEN", ""))
+    parser.add_argument("--authorization-header", default=os.getenv("OSCAR_AUTHORIZATION_HEADER", ""))
+    parser.add_argument("--requested-users", required=True)
+    parser.add_argument("--service-cpu", required=True)
+    parser.add_argument("--service-memory", required=True)
+    parser.add_argument("--mode", default="exploratory", choices=["exploratory", "conservative"])
+    parser.add_argument("--ssl-verify", default="true")
+    parser.add_argument("--quota-retries", type=int, default=6)
+    parser.add_argument("--quota-retry-delay", type=float, default=5.0)
+    return parser.parse_args()
+
+
+def truthy(value: str) -> bool:
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def parse_users(value: str) -> List[int]:
+    users = sorted({int(item.strip()) for item in value.split(",") if item.strip()})
+    return [item for item in users if item > 0]
+
+
+def parse_cpu(value: Any) -> float:
+    text = str(value or "0").strip()
+    if text.lower() in {"none", "null", ""}:
+        return 0.0
+    if text.endswith("m"):
+        return float(text[:-1]) / 1000
+    amount = float(text)
+    # OSCAR quota endpoints may return millicores as plain numbers.
+    return amount / 1000 if amount > 128 else amount
+
+
+def parse_memory_mib(value: Any) -> float:
+    text = str(value or "0Mi").strip()
+    if text.lower() in {"none", "null", ""}:
+        return 0.0
+    match = re.match(r"^([0-9.]+)\s*([A-Za-z]+)?$", text)
+    if not match:
+        return 0.0
+    amount = float(match.group(1))
+    raw_unit = match.group(2)
+    if raw_unit is None and amount >= 1024 * 1024:
+        return amount / (1024 * 1024)
+    unit = (raw_unit or "Mi").lower()
+    factor = {
+        "ki": 1 / 1024,
+        "k": 1 / 1024,
+        "mi": 1,
+        "m": 1,
+        "gi": 1024,
+        "g": 1024,
+        "ti": 1024 * 1024,
+        "t": 1024 * 1024,
+    }.get(unit, 1)
+    return amount * factor
+
+
+def request_json(args: argparse.Namespace, path: str) -> Dict[str, Any]:
+    request = urllib.request.Request(f"{args.endpoint.rstrip('/')}{path}")
+    request.add_header("Accept", "application/json")
+    authorization = auth_header(args)
+    if authorization:
+        request.add_header("Authorization", authorization)
+
+    context = None
+    if not truthy(args.ssl_verify):
+        context = ssl._create_unverified_context()  # nosec B323: test tooling supports self-signed clusters.
+
+    with urllib.request.urlopen(request, context=context, timeout=60) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def auth_header(args: argparse.Namespace) -> str:
+    if args.authorization_header:
+        return args.authorization_header
+    if args.access_token:
+        return f"Bearer {args.access_token}"
+    return ""
+
+
+def fetch_quotas(args: argparse.Namespace) -> Dict[str, Any]:
+    path = "/system/quotas/user"
+    errors = []
+    attempts = max(args.quota_retries, 1)
+    for attempt in range(1, attempts + 1):
+        try:
+            payload = request_json(args, path)
+            return {"path": path, "payload": payload}
+        except urllib.error.HTTPError as exc:
+            body = exc.read().decode("utf-8", errors="replace")
+            error = f"{path}: HTTP {exc.code}: {body}"
+            errors.append(error)
+            if exc.code != 500 or "ClusterQueue" not in body or attempt == attempts:
+                break
+        except Exception as exc:  # noqa: BLE001 - test utility reports the fallback chain.
+            errors.append(f"{path}: {exc}")
+            break
+        time.sleep(args.quota_retry_delay)
+    raise RuntimeError("; ".join(errors))
+
+
+def limit_from_quota(max_value: float, used_value: float, per_invocation: float) -> Optional[int]:
+    if max_value <= 0 or per_invocation <= 0:
+        return None
+    return max(math.floor(max(max_value - used_value, 0.0) / per_invocation), 0)
+
+
+def plan_users(requested: List[int], safe_parallel: Optional[int], mode: str) -> List[int]:
+    if not requested or safe_parallel is None:
+        return requested
+
+    below_or_equal = [item for item in requested if item <= safe_parallel]
+    above = [item for item in requested if item > safe_parallel]
+
+    if mode == "conservative":
+        return below_or_equal or [max(safe_parallel, 1)]
+
+    effective = below_or_equal or [max(safe_parallel, 1)]
+    if above:
+        effective.append(above[0])
+    return sorted({item for item in effective if item > 0})
+
+
+def build_plan(args: argparse.Namespace) -> Dict[str, Any]:
+    requested = parse_users(args.requested_users)
+    service_cpu = parse_cpu(args.service_cpu)
+    service_memory_mib = parse_memory_mib(args.service_memory)
+
+    quota = fetch_quotas(args)
+    resources = quota["payload"].get("resources", {})
+    cpu = resources.get("cpu", {})
+    memory = resources.get("memory", {})
+
+    cpu_max = parse_cpu(cpu.get("max"))
+    cpu_used = parse_cpu(cpu.get("used"))
+    memory_max_mib = parse_memory_mib(memory.get("max"))
+    memory_used_mib = parse_memory_mib(memory.get("used"))
+
+    cpu_limit = limit_from_quota(cpu_max, cpu_used, service_cpu)
+    memory_limit = limit_from_quota(memory_max_mib, memory_used_mib, service_memory_mib)
+    limits = [item for item in (cpu_limit, memory_limit) if item is not None]
+    safe_parallel = min(limits) if limits else None
+    effective = plan_users(requested, safe_parallel, args.mode)
+
+    return {
+        "quota_available": True,
+        "quota_path": quota["path"],
+        "mode": args.mode,
+        "requested_users": requested,
+        "effective_users": effective,
+        "service": {
+            "cpu": service_cpu,
+            "memory_mib": service_memory_mib,
+        },
+        "quota": {
+            "cpu_max_raw": cpu.get("max"),
+            "cpu_used_raw": cpu.get("used"),
+            "cpu_max": cpu_max,
+            "cpu_used": cpu_used,
+            "cpu_available": max(cpu_max - cpu_used, 0.0),
+            "memory_max_raw": memory.get("max"),
+            "memory_used_raw": memory.get("used"),
+            "memory_max_mib": memory_max_mib,
+            "memory_used_mib": memory_used_mib,
+            "memory_available_mib": max(memory_max_mib - memory_used_mib, 0.0),
+        },
+        "limits": {
+            "cpu_parallel": cpu_limit,
+            "memory_parallel": memory_limit,
+            "safe_parallel": safe_parallel,
+        },
+    }
+
+
+def fallback_plan(args: argparse.Namespace, reason: str) -> Dict[str, Any]:
+    requested = parse_users(args.requested_users)
+    return {
+        "quota_available": False,
+        "reason": reason,
+        "mode": args.mode,
+        "requested_users": requested,
+        "effective_users": requested,
+        "service": {
+            "cpu": parse_cpu(args.service_cpu),
+            "memory_mib": parse_memory_mib(args.service_memory),
+        },
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        plan = build_plan(args)
+    except Exception as exc:  # noqa: BLE001 - quota unavailability should not block a load test.
+        plan = fallback_plan(args, str(exc))
+
+    print(json.dumps(plan, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scalability/src/warm_async_invocations.py
+++ b/tests/scalability/src/warm_async_invocations.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Warm the OSCAR asynchronous invocation path before measured Locust steps."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+import urllib.parse
+from pathlib import Path
+from typing import Any, Dict, List
+
+from measure_baseline_invocations import collect_jobs, now, payload, post, truthy, wait_for_job
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--endpoint", required=True)
+    parser.add_argument("--service", required=True)
+    parser.add_argument("--access-token", default=os.getenv("OSCAR_ACCESS_TOKEN", ""))
+    parser.add_argument("--authorization-header", default=os.getenv("OSCAR_AUTHORIZATION_HEADER", ""))
+    parser.add_argument(
+        "--invocation-authorization-header",
+        default=os.getenv("OSCAR_INVOCATION_AUTHORIZATION_HEADER", ""),
+    )
+    parser.add_argument("--payload-file", required=True)
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--ssl-verify", default=os.getenv("SSL_VERIFY", "true"))
+    parser.add_argument("--content-type", default="text/plain")
+    parser.add_argument("--base64-payload", default="true")
+    parser.add_argument("--unique-payload", default="true")
+    parser.add_argument("--jobs", type=int, default=3)
+    parser.add_argument("--submit-interval", type=float, default=1.0)
+    parser.add_argument("--async-timeout", type=float, default=120.0)
+    parser.add_argument("--async-poll-interval", type=float, default=2.0)
+    return parser.parse_args()
+
+
+def submit_and_wait(args: argparse.Namespace, index: int) -> Dict[str, Any]:
+    label = f"async-warmup-{index}"
+    result: Dict[str, Any] = {
+        "label": label,
+        "started_at": now(),
+        "endpoint": f"{args.endpoint.rstrip('/')}/job/{args.service}",
+    }
+    try:
+        before = set(collect_jobs(args))
+        monotonic_start = time.monotonic()
+        status, response_body, elapsed_ms, response_headers = post(
+            args,
+            f"/job/{urllib.parse.quote(args.service)}",
+            payload(args, label),
+        )
+        result["submit"] = {
+            "finished_at": now(),
+            "latency_ms": elapsed_ms,
+            "status_code": status,
+            "ok": status == 201,
+            "response_bytes": len(response_body.encode("utf-8")),
+            "content_type": response_headers.get("Content-Type") or response_headers.get("content-type"),
+        }
+        if status != 201:
+            result["submit"]["error"] = response_body[:500]
+            result["ok"] = False
+            return result
+        result["job"] = wait_for_job(args, before, monotonic_start)
+        result["ok"] = bool(result["submit"]["ok"] and result["job"].get("ok"))
+    except Exception as exc:  # noqa: BLE001 - warm-up should report partial data.
+        result.update({"ok": False, "error": str(exc)})
+    result["finished_at"] = now()
+    return result
+
+
+def run_warmup(args: argparse.Namespace) -> Dict[str, Any]:
+    started = time.monotonic()
+    jobs: List[Dict[str, Any]] = []
+    submit_interval = max(args.submit_interval, 0.0)
+    job_count = max(args.jobs, 0)
+    for index in range(1, job_count + 1):
+        jobs.append(submit_and_wait(args, index))
+        if index < job_count:
+            time.sleep(submit_interval)
+
+    ok_count = sum(1 for item in jobs if item.get("ok"))
+    return {
+        "schema_version": "1.0",
+        "captured_at": now(),
+        "endpoint": args.endpoint.rstrip("/"),
+        "service": args.service,
+        "description": "Asynchronous warm-up jobs submitted before measured Locust async steps.",
+        "config": {
+            "jobs": job_count,
+            "submit_interval_seconds": submit_interval,
+            "base64_payload": truthy(args.base64_payload),
+            "unique_payload": truthy(args.unique_payload),
+            "async_timeout_seconds": args.async_timeout,
+            "async_poll_interval_seconds": args.async_poll_interval,
+        },
+        "summary": {
+            "ok": ok_count == job_count,
+            "jobs": job_count,
+            "succeeded": ok_count,
+            "failed": job_count - ok_count,
+            "elapsed_seconds": time.monotonic() - started,
+        },
+        "jobs": jobs,
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    warmup = run_warmup(args)
+    output = Path(args.output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(warmup, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps(warmup, indent=2, sort_keys=True))
+    return 0 if warmup.get("summary", {}).get("ok") else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scalability/src/write_run_configuration.py
+++ b/tests/scalability/src/write_run_configuration.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Write non-secret run configuration metadata for a scalability experiment."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--endpoint", required=True)
+    parser.add_argument("--service", required=True)
+    parser.add_argument("--experiment-dir", required=True)
+    parser.add_argument("--variable", action="append", default=[], help="Experiment variable as NAME=VALUE. Can be repeated.")
+    return parser.parse_args()
+
+
+def parse_variables(items: List[str]) -> Dict[str, Any]:
+    variables: Dict[str, Any] = {}
+    for item in items:
+        if "=" not in item:
+            continue
+        key, value = item.split("=", 1)
+        variables[key] = coerce_value(value)
+    return variables
+
+
+def coerce_value(value: str) -> Any:
+    normalized = value.strip()
+    if normalized.lower() == "true":
+        return True
+    if normalized.lower() == "false":
+        return False
+    if normalized.lower() in {"none", "null"}:
+        return None
+    return value
+
+
+def env(name: str) -> str:
+    return os.getenv(name, "").strip()
+
+
+def make_command() -> str:
+    auth_goal = env("OSCAR_TEST_AUTH_GOAL")
+    cluster_goal = env("OSCAR_TEST_CLUSTER_GOAL")
+    suite = env("OSCAR_TEST_ROBOT_SUITE")
+    robot_args = env("OSCAR_TEST_ROBOT_ARGS")
+    parts = [shlex.quote(item) for item in ["make", "test", auth_goal, cluster_goal] if item]
+    if suite:
+        parts.append(f"ROBOT_SUITE={shlex.quote(suite)}")
+    if robot_args:
+        parts.append(f"ROBOT_ARGS={shlex.quote(robot_args)}")
+    output_dir = env("OSCAR_TEST_ROBOT_OUTPUT_DIR")
+    if output_dir and output_dir != "robot_results":
+        parts.append(f"ROBOT_OUTPUT_DIR={shlex.quote(output_dir)}")
+    if not auth_goal or not cluster_goal:
+        return ""
+    return " ".join(parts)
+
+
+def robot_command() -> str:
+    robot = env("OSCAR_TEST_ROBOT") or "robot"
+    auth_file = env("OSCAR_TEST_AUTH_FILE")
+    cluster_file = env("OSCAR_TEST_CLUSTER_FILE")
+    robot_args = env("OSCAR_TEST_ROBOT_ARGS")
+    output_dir = env("OSCAR_TEST_ROBOT_OUTPUT_DIR") or "robot_results"
+    suite = env("OSCAR_TEST_ROBOT_SUITE")
+    parts = [shlex.quote(robot)]
+    if auth_file:
+        parts.extend(["-V", shlex.quote(auth_file)])
+    if cluster_file:
+        parts.extend(["-V", shlex.quote(cluster_file)])
+    if robot_args:
+        parts.append(robot_args)
+    parts.extend(["-d", shlex.quote(output_dir)])
+    if suite:
+        parts.append(shlex.quote(suite))
+    return " ".join(parts)
+
+
+def build_payload(args: argparse.Namespace) -> Dict[str, Any]:
+    variables = parse_variables(args.variable)
+    return {
+        "schema_version": "1.0",
+        "captured_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "description": "Non-secret configuration values captured to make the experiment reproducible.",
+        "endpoint": args.endpoint.rstrip("/"),
+        "service": args.service,
+        "experiment_dir": args.experiment_dir,
+        "make": {
+            "auth_goal": env("OSCAR_TEST_AUTH_GOAL") or None,
+            "cluster_goal": env("OSCAR_TEST_CLUSTER_GOAL") or None,
+            "auth_file": env("OSCAR_TEST_AUTH_FILE") or None,
+            "cluster_file": env("OSCAR_TEST_CLUSTER_FILE") or None,
+            "robot": env("OSCAR_TEST_ROBOT") or "robot",
+            "robot_suite": env("OSCAR_TEST_ROBOT_SUITE") or None,
+            "robot_args": env("OSCAR_TEST_ROBOT_ARGS") or None,
+            "robot_output_dir": env("OSCAR_TEST_ROBOT_OUTPUT_DIR") or None,
+        },
+        "commands": {
+            "make": make_command(),
+            "robot": robot_command(),
+        },
+        "variables": variables,
+        "notes": [
+            "Authentication files and cluster variable files are referenced by path only; their contents are not embedded.",
+            "Bearer tokens and credentials are intentionally not captured.",
+            "The command is reconstructed from Makefile metadata when the suite is launched through make.",
+        ],
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    payload = build_payload(args)
+    output = Path(args.output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scalability/stress-api.robot
+++ b/tests/scalability/stress-api.robot
@@ -6,13 +6,15 @@ Resource            ${CURDIR}/../../resources/files.resource
 Resource            ${CURDIR}/../../resources/service.resource
 Library             OperatingSystem
 Library             Process
+Library             RequestsLibrary
 
 Suite Setup         Setup Stress Environment
 Suite Teardown      Teardown Stress Environment
 
 
 *** Variables ***
-${LOCUSTFILE}                   ${CURDIR}/oscar_api.py
+${SCALABILITY_SRC_DIR}          ${CURDIR}/src
+${LOCUSTFILE}                   ${SCALABILITY_SRC_DIR}/oscar_api.py
 ${STRESS_SERVICE_BASE}          robot-test-cowsay
 ${STRESS_SERVICE_NAME}          ${STRESS_SERVICE_BASE}
 ${LOCUST_WAIT_MIN}              1
@@ -23,7 +25,7 @@ ${SMOKE_RUN_TIME}               5s
 ${SUSTAINED_USERS}              20
 ${SUSTAINED_SPAWN_RATE}         5
 ${SUSTAINED_RUN_TIME}           1m
-${LOCUST_OUTPUT_DIR}            ${EXECDIR}/robot_results/locust
+${LOCUST_OUTPUT_DIR}            ${EXECDIR}/robot_results/scalability/stress-api
 ${LOCUST_OUTPUT_PREFIX}         ${LOCUST_OUTPUT_DIR}/latest
 
 
@@ -47,8 +49,8 @@ Setup Stress Environment
     Create Directory    ${LOCUST_OUTPUT_DIR}
     ${output_prefix}=    Catenate    SEPARATOR=/    ${LOCUST_OUTPUT_DIR}    ${service_name}
     Set Suite Variable    ${LOCUST_OUTPUT_PREFIX}    ${output_prefix}
+    Check Valid OIDC Token
     ${access_token}=    Get Access Token
-    Check JWT Expiration    ${access_token}
     Set Suite Variable    ${ACCESS_TOKEN}    ${access_token}
     Set Environment Variable    OSCAR_ACCESS_TOKEN    ${access_token}
     Set Environment Variable    OSCAR_SERVICE_NAME    ${STRESS_SERVICE_NAME}
@@ -80,7 +82,9 @@ Ensure Stress Service Exists
     [Documentation]    Create the stress service if it is not already present.
     ${service_url}=    Catenate    SEPARATOR=    ${OSCAR_ENDPOINT}/system/services/    ${STRESS_SERVICE_NAME}
     ${response}=    GET With Defaults    ${service_url}    expected_status=ANY
-    Run Keyword If    '${response.status_code}'=='200'    RETURN
+    IF    '${response.status_code}'=='200'
+        RETURN
+    END
     Prepare Stress Service File
     ${body}=    Get File    ${DATA_DIR}/stress_service.json
     ${create_response}=    POST With Defaults    url=${OSCAR_ENDPOINT}/system/services    data=${body}

--- a/tests/scalability/viewer/app.js
+++ b/tests/scalability/viewer/app.js
@@ -1,0 +1,523 @@
+(function () {
+  const data = window.OSCAR_SCALABILITY_DATA || { experiments: [] };
+  const experiments = data.experiments || [];
+  const colors = {
+    sync: "#0f766e",
+    async: "#b42318",
+    preRun: "#2563eb",
+    run: "#b7791f",
+    completion: "#6b7280",
+    green: "#0f766e",
+    red: "#b42318",
+    blue: "#2563eb",
+    yellow: "#b7791f",
+  };
+  const tooltip = d3.select("body").append("div").attr("class", "tooltip");
+
+  function fmt(value, digits = 2, suffix = "") {
+    if (value === null || value === undefined || Number.isNaN(value)) return "-";
+    if (typeof value === "number") return `${value.toFixed(digits)}${suffix}`;
+    return `${value}${suffix}`;
+  }
+
+  function stepRows(experiment) {
+    return (experiment.steps || []).map((step) => ({
+      experiment: experiment.experiment_id,
+      mode: step.mode,
+      users: step.users,
+      requests: step.locust?.requests || 0,
+      failures: step.locust?.failures || 0,
+      failureRate: step.locust?.failure_rate || 0,
+      rps: step.locust?.requests_per_second,
+      p95: step.locust?.latency_ms?.p95,
+      completionP95: step.jobs?.completion_seconds?.p95,
+      preRunP95: step.jobs?.pre_run_seconds?.p95,
+      runP95: step.jobs?.run_seconds?.p95,
+      unfinished: step.jobs?.unfinished,
+      statuses: step.jobs?.status_counts || {},
+    }));
+  }
+
+  function selectedExperiment() {
+    const id = d3.select("#experimentSelect").property("value");
+    return experiments.find((item) => item.experiment_id === id) || experiments[0];
+  }
+
+  function init() {
+    const select = d3.select("#experimentSelect");
+    select
+      .selectAll("option")
+      .data(experiments)
+      .join("option")
+      .attr("value", (d) => d.experiment_id)
+      .text((d) => `${d.experiment_id} (${d.created_at})`);
+    select.on("change", render);
+    setupHeaderTooltips();
+    render();
+  }
+
+  function render() {
+    const experiment = selectedExperiment();
+    if (!experiment) {
+      d3.select("main").html("<section><h2>No experiments found</h2><p>Run the scalability suite first.</p></section>");
+      return;
+    }
+    const rows = stepRows(experiment);
+    renderSummary(experiment, rows);
+    renderBaseline(experiment);
+    renderInvocationBaseline(experiment);
+    renderFindings(experiment, rows);
+    renderTable(rows);
+    lineChart("#throughputChart", rows.filter((d) => d.rps !== null && d.rps !== undefined), "rps", "Requests/s", {
+      valueFormatter: (value) => fmt(value, 2, " req/s"),
+    });
+    lineChart("#latencyChart", rows.filter((d) => d.p95 !== null && d.p95 !== undefined), "p95", "P95 HTTP latency (ms)", {
+      labelFor: latencySeriesLabel,
+      valueFormatter: (value) => fmt(value, 0, " ms"),
+    });
+    lineChart("#completionChart", rows.filter((d) => d.mode === "async" && d.completionP95 !== null && d.completionP95 !== undefined), "completionP95", "P95 seconds", {
+      labelFor: () => "async end-to-end",
+      colorFor: () => colors.completion,
+      valueFormatter: (value) => fmt(value, 2, " s"),
+      metricLabel: "P95 end-to-end",
+    });
+    barChart("#failureChart", rows, "failureRate", "Failure rate", (v) => `${(v * 100).toFixed(1)}%`);
+    lifecycleChart("#lifecycleChart", rows.filter((d) => d.mode === "async"));
+    statusChart("#statusChart", rows.filter((d) => d.mode === "async"));
+    renderReproducibility(experiment);
+  }
+
+  function renderSummary(experiment, rows) {
+    const quota = experiment.platform?.quota || {};
+    const totals = {
+      requests: d3.sum(rows, (d) => d.requests),
+      failures: d3.sum(rows, (d) => d.failures),
+      maxP95: d3.max(rows, (d) => d.p95),
+      maxCompletion: d3.max(rows, (d) => d.completionP95),
+      safe: quota.safe_parallel_capacity,
+    };
+    const cards = [
+      ["Experiment", experiment.experiment_id],
+      ["Total requests", totals.requests],
+      ["HTTP failures", totals.failures],
+      ["Max HTTP P95", fmt(totals.maxP95, 0, " ms")],
+      ["Max async E2E P95", fmt(totals.maxCompletion, 2, " s")],
+      ["Quota safe capacity", fmt(totals.safe, 0)],
+    ];
+    d3.select("#summary")
+      .selectAll(".metric")
+      .data(cards)
+      .join("div")
+      .attr("class", "metric")
+      .html((d) => `<span>${escapeHtml(d[0])}</span><strong>${escapeHtml(d[1])}</strong>`);
+  }
+
+  function renderReproducibility(experiment) {
+    const config = experiment.run_configuration || {};
+    const hasConfig = Boolean(Object.keys(config).length);
+    d3.select("#reproducibilitySection").style("display", hasConfig ? null : "none");
+    if (!hasConfig) return;
+
+    const command = config.commands?.make || config.commands?.robot || "";
+    d3.select("#reproducibilityCommand").text(command || "Command metadata was not available for this experiment.");
+
+    d3.select("#reproducibilityNotes")
+      .selectAll("li")
+      .data(config.notes || [])
+      .join("li")
+      .text((d) => d);
+  }
+
+  function renderFindings(experiment, rows) {
+    const findings = [];
+    const safe = experiment.platform?.quota?.safe_parallel_capacity;
+    if (safe !== null && safe !== undefined) findings.push(`Quota-derived safe parallel capacity is ${safe} invocations.`);
+    ["sync", "async"].forEach((mode) => {
+      const failed = rows.filter((d) => d.mode === mode && d.failures > 0).sort((a, b) => a.users - b.users)[0];
+      findings.push(
+        failed
+          ? `${mode} first shows HTTP failures at ${failed.users} users (${(failed.failureRate * 100).toFixed(1)}%).`
+          : `${mode} has no HTTP failures in the executed steps.`
+      );
+    });
+    const unfinished = rows.filter((d) => d.mode === "async" && (d.unfinished || 0) > 0).sort((a, b) => a.users - b.users)[0];
+    if (unfinished) findings.push(`Async has unfinished jobs from ${unfinished.users} users with the configured settle time.`);
+    d3.select("#findings").selectAll("li").data(findings).join("li").text((d) => d);
+  }
+
+  function renderBaseline(experiment) {
+    const quota = experiment.platform?.quota || {};
+    const clusterStatus = experiment.cluster_status || experiment.platform?.cluster_status || {};
+    const clusterResources = clusterResourcesFromStatus(experiment);
+    const clusterCpu = clusterResources.cpu || {};
+    const clusterMemory = clusterResources.memory || {};
+    const service = experiment.service || {};
+    const invocationResources = service.invocation_resources || fallbackInvocationResources(experiment);
+    const serviceCards = [
+      ["Service", service.name || "-"],
+      ["OSCAR Hub", service.hub?.url ? { text: service.hub?.name || service.base || "service", href: service.hub.url } : "-"],
+      ...Object.entries(invocationResources).map(([mode, resources]) => [
+        `${mode} invocation resources`,
+        `${fmt(resources.cpu_cores, 2, " CPU")} / ${fmt(resources.memory_mib, 0, " MiB")}`,
+        "CPU and memory requested by the deployed OSCAR service for each invocation in this mode.",
+      ]),
+    ];
+    d3.select("#clusterEndpoint").html(
+      `<span>Cluster endpoint</span><strong>${escapeHtml(experiment.platform?.endpoint || "-")}</strong>`
+    );
+    const clusterCards = [
+      ["Cluster total free CPU", fmt(clusterCpu.total_free_cores, 2, " cores")],
+      ["Cluster max node CPU", fmt(clusterCpu.max_free_on_node_cores, 2, " cores")],
+      ["Cluster total free memory", fmt(clusterMemory.total_free_mib, 0, " MiB")],
+      ["Cluster max node memory", fmt(clusterMemory.max_free_on_node_mib, 0, " MiB")],
+      ["Nodes", fmt(clusterResources.nodes_count, 0)],
+      ["Captured at", clusterStatus.captured_at || "-"],
+    ];
+    const quotaCards = [
+      ["Quota source", experiment.platform?.quota_source || "unavailable"],
+      ["User quota free CPU", fmt(quota.cpu_available_cores, 2, " cores")],
+      ["User quota free memory", fmt(quota.memory_available_mib, 0, " MiB")],
+      [
+        "Safe capacity",
+        fmt(quota.safe_parallel_capacity, 0),
+        "Estimated maximum parallel simple-test invocations that fit within the user's available CPU and memory quota.",
+      ],
+    ];
+
+    renderCards("#serviceCards", serviceCards);
+    renderCards("#clusterResourceCards", clusterCards);
+    renderCards("#quotaCards", quotaCards);
+  }
+
+  function renderInvocationBaseline(experiment) {
+    const baseline = experiment.baseline || {};
+    const hasBaseline = Boolean(Object.keys(baseline).length);
+    d3.select("#invocationBaselineSection").style("display", hasBaseline ? null : "none");
+    if (!hasBaseline) return;
+
+    const syncFirst = baseline.sync?.first_ready || {};
+    const syncWarm = baseline.sync?.warm || {};
+    const asyncFirst = baseline.async?.first_ready || {};
+    const asyncWarm = baseline.async?.warm || {};
+    const asyncWarmup = experiment.async_warmup?.summary || {};
+    const cards = [
+      [
+        "Sync first ready",
+        invocationValue(syncFirst.latency_ms, " ms", syncFirst.ok),
+        "First synchronous /run invocation measured after the service was reported as ready.",
+      ],
+      [
+        "Sync warm",
+        invocationValue(syncWarm.latency_ms, " ms", syncWarm.ok),
+        "Second synchronous /run invocation measured immediately after the first ready invocation.",
+      ],
+      [
+        "Sync first/warm ratio",
+        ratioValue(syncFirst.latency_ms, syncWarm.latency_ms),
+        "Ratio between first ready sync latency and warm sync latency. Values above 1 indicate the first call was slower.",
+      ],
+      [
+        "Async first submit",
+        invocationValue(asyncFirst.submit?.latency_ms, " ms", asyncFirst.submit?.ok),
+        "HTTP latency for the first isolated asynchronous /job submission.",
+      ],
+      [
+        "Async first end-to-end",
+        invocationValue(asyncFirst.job?.completion_seconds, " s", asyncFirst.job?.ok),
+        "Completion time for the first isolated asynchronous job, from creation to terminal state.",
+      ],
+      [
+        "Async warm submit",
+        invocationValue(asyncWarm.submit?.latency_ms, " ms", asyncWarm.submit?.ok),
+        "HTTP latency for the second isolated asynchronous /job submission.",
+      ],
+      [
+        "Async warm end-to-end",
+        invocationValue(asyncWarm.job?.completion_seconds, " s", asyncWarm.job?.ok),
+        "Completion time for the second isolated asynchronous job, from creation to terminal state.",
+      ],
+      [
+        "Async first/warm ratio",
+        ratioValue(asyncFirst.job?.completion_seconds, asyncWarm.job?.completion_seconds),
+        "Ratio between first ready async end-to-end time and warm async end-to-end time.",
+      ],
+    ];
+    if (Object.keys(asyncWarmup).length) {
+      cards.push(
+        [
+          "Async warm-up jobs",
+          `${fmt(asyncWarmup.succeeded, 0)} / ${fmt(asyncWarmup.jobs, 0)} succeeded`,
+          "Asynchronous jobs submitted and completed before the measured async Locust steps.",
+        ],
+        [
+          "Async warm-up elapsed",
+          fmt(asyncWarmup.elapsed_seconds, 2, " s"),
+          "Wall-clock time spent warming the asynchronous path before measured async load.",
+        ]
+      );
+    }
+
+    renderCards("#invocationBaselineCards", cards);
+    d3.select("#invocationBaselineCaveats")
+      .selectAll("li")
+      .data(baseline.caveats || [])
+      .join("li")
+      .text((d) => d);
+  }
+
+  function invocationValue(value, suffix, ok) {
+    const digits = suffix.trim() === "ms" ? 0 : 2;
+    const formatted = fmt(value, digits, suffix);
+    if (formatted === "-") return ok === false ? "failed" : "-";
+    return ok === false ? `${formatted} (failed)` : formatted;
+  }
+
+  function ratioValue(first, warm) {
+    if (!Number.isFinite(Number(first)) || !Number.isFinite(Number(warm)) || Number(warm) === 0) return "-";
+    return `${(Number(first) / Number(warm)).toFixed(2)}x`;
+  }
+
+  function renderCards(selector, cards) {
+    d3.select(selector)
+      .selectAll(".baseline-item")
+      .data(cards)
+      .join("div")
+      .attr("class", "baseline-item")
+      .attr("data-help", (d) => d[2] || null)
+      .html((d) => `<span>${escapeHtml(d[0])}</span><strong>${formatCardValue(d[1])}</strong>`)
+      .on("mousemove", (event, d) => {
+        if (d[2]) showTip(event, d[2]);
+      })
+      .on("mouseleave", hideTip);
+  }
+
+  function formatCardValue(value) {
+    if (value && typeof value === "object" && value.href) {
+      return `<a href="${escapeHtml(value.href)}" target="_blank" rel="noopener noreferrer">${escapeHtml(value.text || value.href)}</a>`;
+    }
+    return escapeHtml(value);
+  }
+
+  function fallbackInvocationResources(experiment) {
+    const modes = Array.from(new Set((experiment.steps || []).map((step) => step.mode))).sort();
+    const service = experiment.service || {};
+    const cpu = service.resources?.cpu_cores ?? service.cpu;
+    const memory = service.resources?.memory_mib ?? service.memory_mib;
+    return Object.fromEntries(modes.map((mode) => [mode, { cpu_cores: cpu, memory_mib: memory }]));
+  }
+
+  function clusterResourcesFromStatus(experiment) {
+    const status = experiment.cluster_status || experiment.platform?.cluster_status || {};
+    const direct = experiment.platform?.cluster_resources || status.resources || {};
+    if (Object.keys(direct).length) return direct;
+    return normalizeClusterResources(status.payload);
+  }
+
+  function normalizeClusterResources(payload) {
+    const cluster = payload?.cluster || {};
+    const metrics = cluster.metrics || {};
+    const cpu = metrics.cpu || {};
+    const memory = metrics.memory || {};
+    const nodes = Array.isArray(cluster.nodes) ? cluster.nodes : [];
+    const nodeCpuCapacity = nodes.map((node) => cpuToCores(node?.cpu?.capacity_cores)).filter((value) => value !== null);
+    const nodeCpuUsage = nodes.map((node) => cpuToCores(node?.cpu?.usage_cores)).filter((value) => value !== null);
+    const nodeMemoryCapacity = nodes.map((node) => bytesToMib(node?.memory?.capacity_bytes)).filter((value) => value !== null);
+    const nodeMemoryUsage = nodes.map((node) => bytesToMib(node?.memory?.usage_bytes)).filter((value) => value !== null);
+    return {
+      nodes_count: cluster.nodes_count ?? nodes.length,
+      cpu: {
+        total_free_cores: cpuToCores(cpu.total_free_cores),
+        max_free_on_node_cores: cpuToCores(cpu.max_free_on_node_cores),
+        total_capacity_cores: sumOrNull(nodeCpuCapacity),
+        total_used_cores: sumOrNull(nodeCpuUsage),
+      },
+      memory: {
+        total_free_mib: bytesToMib(memory.total_free_bytes),
+        max_free_on_node_mib: bytesToMib(memory.max_free_on_node_bytes),
+        total_capacity_mib: sumOrNull(nodeMemoryCapacity),
+        total_used_mib: sumOrNull(nodeMemoryUsage),
+      },
+      gpu: {
+        total: metrics.gpu?.total_gpu,
+      },
+    };
+  }
+
+  function cpuToCores(value) {
+    const amount = Number(value);
+    if (!Number.isFinite(amount)) return null;
+    return amount > 128 ? amount / 1000 : amount;
+  }
+
+  function bytesToMib(value) {
+    const amount = Number(value);
+    if (!Number.isFinite(amount)) return null;
+    return amount / (1024 * 1024);
+  }
+
+  function sumOrNull(values) {
+    return values.length ? d3.sum(values) : null;
+  }
+
+  function renderTable(rows) {
+    d3.select("#stepsTable tbody")
+      .selectAll("tr")
+      .data(rows.slice().sort((a, b) => d3.ascending(a.mode, b.mode) || d3.ascending(a.users, b.users)))
+      .join("tr")
+      .html(
+        (d) => `
+        <td>${d.mode}</td>
+        <td>${d.users}</td>
+        <td>${d.requests}</td>
+        <td>${d.failures}</td>
+        <td>${(d.failureRate * 100).toFixed(1)}%</td>
+        <td>${fmt(d.rps, 2)}</td>
+        <td>${fmt(d.p95, 0, " ms")}</td>
+        <td>${fmt(d.completionP95, 2, " s")}</td>
+        <td>${fmt(d.preRunP95, 2, " s")}</td>
+        <td>${fmt(d.unfinished, 0)}</td>`
+      );
+  }
+
+  function chartFrame(selector) {
+    const root = d3.select(selector);
+    root.selectAll("*").remove();
+    const width = root.node().clientWidth || 520;
+    const height = 300;
+    const margin = { top: 22, right: 26, bottom: 48, left: 60 };
+    const svg = root.append("svg").attr("viewBox", `0 0 ${width} ${height}`);
+    const legendNode = root.append("div").attr("class", "chart-legend");
+    return { svg, legendNode, width, height, margin, innerW: width - margin.left - margin.right, innerH: height - margin.top - margin.bottom };
+  }
+
+  function lineChart(selector, rows, metric, yLabel, options = {}) {
+    const c = chartFrame(selector);
+    if (!rows.length) return emptyChart(c.svg, c.width, c.height);
+    const valueFormatter = options.valueFormatter || ((value) => fmt(value, 2));
+    const labelFor = options.labelFor || ((name) => name);
+    const colorFor = options.colorFor || ((name) => colors[name] || colors.blue);
+    const xDomain = d3.extent(rows, (d) => d.users);
+    if (xDomain[0] === xDomain[1]) {
+      xDomain[0] = Math.max(0, xDomain[0] - 1);
+      xDomain[1] = xDomain[1] + 1;
+    }
+    const x = d3.scaleLinear().domain(xDomain).nice().range([c.margin.left, c.width - c.margin.right]);
+    const y = d3.scaleLinear().domain([0, d3.max(rows, (d) => d[metric]) || 1]).nice().range([c.height - c.margin.bottom, c.margin.top]);
+    addAxes(c.svg, x, y, c, yLabel);
+    const line = d3.line().x((d) => x(d.users)).y((d) => y(d[metric]));
+    const bySeries = d3.group(rows, (d) => d.mode);
+    for (const [series, values] of bySeries) {
+      c.svg.append("path").datum(values.sort((a, b) => a.users - b.users)).attr("fill", "none").attr("stroke", colorFor(series)).attr("stroke-width", 3).attr("d", line);
+      c.svg
+        .selectAll(`circle.${series}-${metric}`)
+        .data(values)
+        .join("circle")
+        .attr("cx", (d) => x(d.users))
+        .attr("cy", (d) => y(d[metric]))
+        .attr("r", 4)
+        .attr("fill", colorFor(series))
+        .on("mousemove", (event, d) =>
+          showTip(event, {
+            ...d,
+            metricLabel: options.metricLabel || yLabel,
+            seriesLabel: labelFor(series),
+            value: valueFormatter(d[metric]),
+          })
+        )
+        .on("mouseleave", hideTip);
+    }
+    legend(c, Array.from(bySeries.keys()), null, labelFor, colorFor);
+  }
+
+  function barChart(selector, rows, metric, label, valueFormatter) {
+    const c = chartFrame(selector);
+    const x = d3.scaleBand().domain(rows.map((d) => `${d.mode} ${d.users}u`)).range([c.margin.left, c.width - c.margin.right]).padding(0.24);
+    const y = d3.scaleLinear().domain([0, d3.max(rows, (d) => d[metric]) || 1]).nice().range([c.height - c.margin.bottom, c.margin.top]);
+    addAxes(c.svg, x, y, c, label);
+    c.svg.selectAll("rect").data(rows).join("rect").attr("x", (d) => x(`${d.mode} ${d.users}u`)).attr("y", (d) => y(d[metric])).attr("width", x.bandwidth()).attr("height", (d) => y(0) - y(d[metric])).attr("fill", (d) => (d[metric] > 0 ? colors.red : colors.sync)).on("mousemove", (event, d) => showTip(event, { ...d, value: valueFormatter(d[metric]) })).on("mouseleave", hideTip);
+  }
+
+  function lifecycleChart(selector, rows) {
+    const c = chartFrame(selector);
+    if (!rows.length) return emptyChart(c.svg, c.width, c.height);
+    const keys = ["preRunP95", "runP95"];
+    const x = d3.scaleBand().domain(rows.map((d) => `${d.users}u`)).range([c.margin.left, c.width - c.margin.right]).padding(0.25);
+    const y = d3.scaleLinear().domain([0, d3.max(rows, (d) => (d.preRunP95 || 0) + (d.runP95 || 0)) || 1]).nice().range([c.height - c.margin.bottom, c.margin.top]);
+    addAxes(c.svg, x, y, c, "P95 seconds");
+    const stacked = d3.stack().keys(keys)(rows);
+    c.svg.selectAll("g.stack").data(stacked).join("g").attr("fill", (d) => (d.key === "preRunP95" ? colors.preRun : colors.run)).selectAll("rect").data((d) => d).join("rect").attr("x", (d) => x(`${d.data.users}u`)).attr("y", (d) => y(d[1])).attr("height", (d) => y(d[0]) - y(d[1])).attr("width", x.bandwidth());
+    legend(c, ["pre-run", "run"], null, (name) => name, (name) => (name === "pre-run" ? colors.preRun : colors.run));
+  }
+
+  function statusChart(selector, rows) {
+    const c = chartFrame(selector);
+    if (!rows.length) return emptyChart(c.svg, c.width, c.height);
+    const statuses = Array.from(new Set(rows.flatMap((d) => Object.keys(d.statuses))));
+    const x = d3.scaleBand().domain(rows.map((d) => `${d.users}u`)).range([c.margin.left, c.width - c.margin.right]).padding(0.25);
+    const y = d3.scaleLinear().domain([0, d3.max(rows, (d) => d3.sum(statuses, (s) => d.statuses[s] || 0)) || 1]).nice().range([c.height - c.margin.bottom, c.margin.top]);
+    const color = d3.scaleOrdinal().domain(statuses).range(["#0f766e", "#b7791f", "#b42318", "#2563eb", "#6b7280"]);
+    addAxes(c.svg, x, y, c, "Jobs");
+    const stacked = d3.stack().keys(statuses).value((d, key) => d.statuses[key] || 0)(rows);
+    c.svg.selectAll("g.status").data(stacked).join("g").attr("fill", (d) => color(d.key)).selectAll("rect").data((d) => d).join("rect").attr("x", (d) => x(`${d.data.users}u`)).attr("y", (d) => y(d[1])).attr("height", (d) => y(d[0]) - y(d[1])).attr("width", x.bandwidth());
+    legend(c, statuses, color);
+  }
+
+  function addAxes(svg, x, y, c, yLabel) {
+    svg.append("g").attr("class", "axis").attr("transform", `translate(0,${c.height - c.margin.bottom})`).call(d3.axisBottom(x).ticks ? d3.axisBottom(x).ticks(5) : d3.axisBottom(x));
+    svg.append("g").attr("class", "axis").attr("transform", `translate(${c.margin.left},0)`).call(d3.axisLeft(y).ticks(5));
+    svg.append("text").attr("class", "label").attr("x", c.margin.left).attr("y", 14).text(yLabel);
+  }
+
+  function latencySeriesLabel(mode) {
+    if (mode === "sync") return "sync /run response";
+    if (mode === "async") return "async /job submit";
+    return mode;
+  }
+
+  function legend(c, names, colorScale, labelFor = (name) => name, colorFor = null) {
+    c.legendNode
+      .selectAll(".legend-item")
+      .data(names)
+      .join("div")
+      .attr("class", "legend-item")
+      .html(
+        (name) => `
+          <span class="legend-swatch" style="background:${colorFor ? colorFor(name) : colorScale ? colorScale(name) : colors[name]}"></span>
+          <span>${escapeHtml(labelFor(name))}</span>
+        `
+      );
+  }
+
+  function emptyChart(svg, width, height) {
+    svg.append("text").attr("x", width / 2).attr("y", height / 2).attr("text-anchor", "middle").attr("class", "label").text("No data available");
+  }
+
+  function setupHeaderTooltips() {
+    d3.selectAll("[data-help]")
+      .on("mousemove", (event) => showTip(event, event.currentTarget.dataset.help))
+      .on("mouseleave", hideTip);
+  }
+
+  function showTip(event, d) {
+    const html =
+      typeof d === "string"
+        ? escapeHtml(d)
+        : `${escapeHtml(d.seriesLabel || d.mode || "")} ${escapeHtml(d.users || "")} users<br>${escapeHtml(d.metricLabel || "value")}: ${escapeHtml(d.value || "")}`;
+    tooltip.style("opacity", 1).style("left", `${event.clientX}px`).style("top", `${event.clientY}px`).html(html);
+  }
+
+  function hideTip() {
+    tooltip.style("opacity", 0);
+  }
+
+  function escapeHtml(value) {
+    return String(value ?? "")
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#39;");
+  }
+
+  init();
+})();

--- a/tests/scalability/viewer/index.html
+++ b/tests/scalability/viewer/index.html
@@ -1,0 +1,154 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>OSCAR Scalability Experiments</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <header class="topbar">
+    <div>
+      <h1>OSCAR Scalability Experiments</h1>
+      <p>Compare synchronous invocations, asynchronous submissions, and job lifecycle timings.</p>
+    </div>
+    <div class="toolbar">
+      <label for="experimentSelect">Experiment</label>
+      <select id="experimentSelect"></select>
+    </div>
+  </header>
+
+  <main>
+    <section class="summary" id="summary"></section>
+
+    <section>
+      <h2>Platform Baseline</h2>
+      <p id="clusterEndpoint" class="endpoint-line"></p>
+      <div class="baseline-split">
+        <div>
+          <h3>Deployed Service</h3>
+          <div id="serviceCards" class="baseline-grid"></div>
+        </div>
+        <div>
+          <h3>Cluster Status (/system/status)</h3>
+          <div id="clusterResourceCards" class="baseline-grid"></div>
+        </div>
+        <div>
+          <h3>User Quotas (/system/quotas/user)</h3>
+          <div id="quotaCards" class="baseline-grid"></div>
+        </div>
+      </div>
+    </section>
+
+    <section id="invocationBaselineSection">
+      <h2>Invocation Baseline</h2>
+      <p class="section-note">Isolated calls measured after the service is reported as ready and before the Locust load steps. This is not a guaranteed node-level cold start; Docker image cache state is not controlled.</p>
+      <div id="invocationBaselineCards" class="baseline-grid"></div>
+      <details class="details-block">
+        <summary>Baseline caveats</summary>
+        <ul id="invocationBaselineCaveats"></ul>
+      </details>
+    </section>
+
+    <section>
+      <h2>Key Findings</h2>
+      <ul id="findings" class="findings"></ul>
+    </section>
+
+    <section>
+      <h2>Latency Reading Guide</h2>
+      <div class="guide-grid">
+        <div class="guide-item">
+          <strong>Sync latency</strong>
+          <span>Full HTTP response time for <code>/run</code>. It includes OSCAR Manager, scheduling, execution, output handling, and the returned response.</span>
+        </div>
+        <div class="guide-item">
+          <strong>Async submit latency</strong>
+          <span>HTTP response time for <code>/job</code>. It measures how long OSCAR takes to accept the job, not how long the job takes to finish.</span>
+        </div>
+        <div class="guide-item">
+          <strong>Async end-to-end</strong>
+          <span>Elapsed time from job submission to final state, collected from OSCAR Manager after the load step.</span>
+        </div>
+        <div class="guide-item">
+          <strong>Async pre-run/run</strong>
+          <span>Pre-run time covers the interval from job creation until OSCAR reports execution start. It may include controller reconciliation, admission, scheduling, image handling, and container startup. Run time approximates the service execution lifecycle.</span>
+        </div>
+      </div>
+    </section>
+
+    <section>
+      <h2>Experiment Steps</h2>
+      <div class="table-wrap">
+        <table id="stepsTable">
+          <thead>
+            <tr>
+              <th data-help="Sync invokes POST /run/{service}. Async submits jobs through POST /job/{service}.">Mode</th>
+              <th data-help="Locust concurrent users configured for this run.">Users</th>
+              <th data-help="Completed HTTP requests recorded by Locust.">Requests</th>
+              <th data-help="Failed HTTP requests recorded by Locust.">Failures</th>
+              <th data-help="Failures divided by total requests.">Failure Rate</th>
+              <th data-help="Average request throughput reported by Locust.">Req/s</th>
+              <th data-help="95th percentile of sync invocation latency, or async job submission latency.">P95 Submit/Run</th>
+              <th data-help="Async job completion latency from submission to final state.">P95 End-to-End</th>
+              <th data-help="Async time from job creation until OSCAR reports execution start.">P95 Pre-run</th>
+              <th data-help="Async jobs not completed when the collector queried OSCAR Manager.">Unfinished Jobs</th>
+            </tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+      </div>
+    </section>
+
+    <section class="chart-grid">
+      <article>
+        <h2>Throughput vs Load</h2>
+        <p class="chart-note">HTTP requests completed per second by Locust.</p>
+        <div id="throughputChart" class="chart"></div>
+      </article>
+      <article>
+        <h2>HTTP Request Latency P95</h2>
+        <p class="chart-note">Sync is full <code>/run</code> response time. Async is only <code>/job</code> submission time.</p>
+        <div id="latencyChart" class="chart"></div>
+      </article>
+      <article>
+        <h2>Async End-to-End P95</h2>
+        <p class="chart-note">Job completion latency from submission to terminal state.</p>
+        <div id="completionChart" class="chart"></div>
+      </article>
+      <article>
+        <h2>HTTP Failure Rate</h2>
+        <p class="chart-note">HTTP failures divided by total Locust requests.</p>
+        <div id="failureChart" class="chart"></div>
+      </article>
+      <article>
+        <h2>Async Pre-run and Run P95</h2>
+        <p class="chart-note">Stacked p95 pre-run and run time for asynchronous jobs.</p>
+        <div id="lifecycleChart" class="chart"></div>
+      </article>
+      <article>
+        <h2>Job Status Composition</h2>
+        <p class="chart-note">Final job states collected after the async settle period.</p>
+        <div id="statusChart" class="chart"></div>
+      </article>
+    </section>
+
+    <section id="reproducibilitySection">
+      <h2>Reproducibility</h2>
+      <p class="section-note">Command captured when the experiment was launched. Token and credential contents are not embedded.</p>
+      <div class="command-block">
+        <h3>Command</h3>
+        <pre id="reproducibilityCommand"></pre>
+      </div>
+      <details class="details-block">
+        <summary>Reproducibility notes</summary>
+        <ul id="reproducibilityNotes"></ul>
+      </details>
+    </section>
+  </main>
+
+  <script src="https://cdn.jsdelivr.net/npm/d3@7"></script>
+  <script src="../../../robot_results/scalability/viewer/data/experiments.js"></script>
+  <script src="app.js"></script>
+</body>
+</html>

--- a/tests/scalability/viewer/styles.css
+++ b/tests/scalability/viewer/styles.css
@@ -1,0 +1,409 @@
+:root {
+  color-scheme: light;
+  --ink: #172026;
+  --muted: #5b6775;
+  --line: #d8e0e8;
+  --panel: #ffffff;
+  --page: #f4f7f9;
+  --green: #0f766e;
+  --red: #b42318;
+  --blue: #2563eb;
+  --yellow: #b7791f;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--page);
+  color: var(--ink);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.topbar {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 28px 36px;
+  background: #18332f;
+  color: white;
+}
+
+.topbar h1 {
+  margin: 0 0 6px;
+  font-size: 30px;
+}
+
+.topbar p {
+  margin: 0;
+  color: #d5e7e2;
+}
+
+.toolbar {
+  display: grid;
+  gap: 6px;
+  min-width: 280px;
+}
+
+select {
+  min-height: 38px;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 8px 10px;
+  font: inherit;
+}
+
+main {
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 24px;
+}
+
+section,
+article,
+.metric {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+}
+
+section {
+  padding: 18px;
+  margin-bottom: 18px;
+}
+
+article {
+  padding: 16px;
+}
+
+h2 {
+  margin: 0 0 14px;
+  font-size: 19px;
+}
+
+h3 {
+  margin: 0 0 10px;
+  font-size: 15px;
+}
+
+.summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+  gap: 14px;
+  background: transparent;
+  border: 0;
+  padding: 0;
+}
+
+.metric {
+  padding: 16px;
+}
+
+.metric span {
+  display: block;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.metric strong {
+  display: block;
+  margin-top: 6px;
+  font-size: 24px;
+}
+
+.baseline-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+  gap: 12px;
+  margin-bottom: 18px;
+}
+
+.baseline-split {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 18px;
+}
+
+.endpoint-line {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  margin: 0 0 14px;
+  color: var(--muted);
+  min-width: 0;
+}
+
+.endpoint-line span {
+  flex: 0 0 auto;
+  font-size: 13px;
+}
+
+.endpoint-line strong {
+  color: var(--ink);
+  font-size: 15px;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.section-note {
+  margin: -4px 0 14px;
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.baseline-item {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 12px;
+  min-width: 0;
+}
+
+.baseline-item span {
+  display: block;
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.baseline-item[data-help] {
+  cursor: help;
+}
+
+.baseline-item strong {
+  display: block;
+  margin-top: 4px;
+  font-size: 18px;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  line-height: 1.25;
+}
+
+.baseline-item a {
+  color: var(--blue);
+  text-decoration: none;
+}
+
+.baseline-item a:hover {
+  text-decoration: underline;
+}
+
+.findings {
+  margin: 0;
+  padding-left: 20px;
+}
+
+.findings li {
+  margin: 6px 0;
+}
+
+.details-block {
+  margin-top: 10px;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.details-block summary {
+  cursor: pointer;
+  color: var(--ink);
+  font-weight: 600;
+}
+
+.details-block ul {
+  margin: 8px 0 0;
+  padding-left: 20px;
+}
+
+.details-block li {
+  margin: 4px 0;
+}
+
+.command-block {
+  margin: 12px 0 14px;
+}
+
+.command-block h3 {
+  margin-bottom: 6px;
+}
+
+.command-block pre {
+  margin: 0;
+  padding: 12px;
+  overflow-x: auto;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: #eef3f6;
+  color: var(--ink);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  font-size: 13px;
+  line-height: 1.45;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.guide-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+  gap: 12px;
+}
+
+.guide-item {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 12px;
+  min-width: 0;
+}
+
+.guide-item strong {
+  display: block;
+  margin-bottom: 6px;
+}
+
+.guide-item span {
+  display: block;
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.guide-item code,
+.chart-note code {
+  color: var(--ink);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  font-size: 0.95em;
+}
+
+.table-wrap {
+  overflow-x: auto;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14px;
+}
+
+th,
+td {
+  padding: 10px 9px;
+  border-bottom: 1px solid var(--line);
+  text-align: right;
+  white-space: nowrap;
+}
+
+th:first-child,
+td:first-child {
+  text-align: left;
+}
+
+th {
+  background: #eef3f6;
+  color: #334155;
+}
+
+th[data-help] {
+  cursor: help;
+  text-decoration: underline;
+  text-decoration-style: dotted;
+  text-underline-offset: 3px;
+}
+
+.chart-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(420px, 1fr));
+  gap: 18px;
+  background: transparent;
+  border: 0;
+  padding: 0;
+}
+
+.chart {
+  min-height: 300px;
+}
+
+.chart-note {
+  min-height: 36px;
+  margin: -4px 0 10px;
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.chart svg {
+  display: block;
+  width: 100%;
+}
+
+.chart-legend {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 8px 18px;
+  min-height: 20px;
+  margin-top: 8px;
+  color: #475569;
+  font-size: 12px;
+}
+
+.legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.legend-swatch {
+  width: 12px;
+  height: 12px;
+  flex: 0 0 12px;
+}
+
+.axis path,
+.axis line,
+.grid-line {
+  stroke: #94a3b8;
+}
+
+.axis text,
+.label {
+  fill: #475569;
+  font-size: 12px;
+}
+
+.tooltip {
+  position: fixed;
+  pointer-events: none;
+  background: rgba(23, 32, 38, 0.92);
+  color: white;
+  padding: 8px 10px;
+  border-radius: 6px;
+  font-size: 13px;
+  opacity: 0;
+  transform: translate(-50%, -120%);
+  max-width: 280px;
+  line-height: 1.35;
+}
+
+@media (max-width: 720px) {
+  .topbar {
+    display: block;
+    padding: 22px;
+  }
+
+  .toolbar {
+    margin-top: 18px;
+  }
+
+  main {
+    padding: 16px;
+  }
+
+  .chart-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .baseline-split {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
Introduce a dedicated scalability test suite for OSCAR services, replacing the previous Locust stress test entry point with a Robot-driven workflow under tests/scalability.

Add support for quota-aware scalability planning, cluster status capture, baseline invocation measurement, sync and async load execution, result collection, experiment JSON generation, and a static D3-based viewer for comparing scalability experiments.

Add async-specific behavior for more stable measurements:
- warm up async invocations before measured runs
- configure async Locust pacing independently from sync pacing
- retry transient sync baseline failures while services are becoming ready
- record async warm-up artifacts in the generated experiment output

Rename the async lifecycle timing metric from queue_seconds to pre_run_seconds. The new name reflects that the interval covers the full time from job creation until execution starts, including controller reconciliation, admission, scheduling, image handling, and container startup.

Update the Makefile to pass arbitrary Robot arguments, expose test execution metadata to suites, and add cleanup targets for Robot and scalability results.

Update Docker dependencies to include Locust, add sample simple-test service data, move shared OSCAR API helpers into the scalability suite, and document the new scalability workflow, artifacts, variables, and viewer usage.

Update ignore rules for generated scalability viewer HTML, Robot outputs, and Python cache files.