### PR TITLE
[codex] add hidden-service visibility coverage to system metrics tests

### DIFF
--- a/tests/api/system-metrics.robot
+++ b/tests/api/system-metrics.robot
@@ -96,6 +96,38 @@ OSCAR System Metrics Invalid Range
     Log    ${response.content}
     Should Contain    ${response.content}    error
 
+OSCAR System Metrics Hidden Service Is Not Visible To Other User
+    [Documentation]    Create a private service with one OIDC user and verify another OIDC user cannot see its metrics.
+    Ensure Auxiliary Metrics Authentication
+    Ensure Invocation Service Ready
+    Wait Until Keyword Succeeds
+    ...    ${SERVICE_TIMEOUT}
+    ...    ${SERVICE_RETRY_INTERVAL}
+    ...    Invoke Sync Metrics Service
+    Wait Until Keyword Succeeds
+    ...    ${METRICS_TIMEOUT}
+    ...    ${METRICS_RETRY_INTERVAL}
+    ...    Service Metric Should Be At Least
+    ...    ${INVOCATION_SERVICE_NAME}
+    ...    requests-sync-per-service
+    ...    1
+    ${end}=    Current Metrics End Timestamp
+    ${response}=    GET With Defaults
+    ...    url=${OSCAR_ENDPOINT}/system/metrics/${INVOCATION_SERVICE_NAME}?metric=requests-sync-per-service&start=${METRICS_TEST_START}&end=${end}
+    ...    expected_status=403
+    ...    headers=${HEADERS2}
+    Log    ${response.content}
+    Should Be Equal As Strings    ${response.status_code}    403
+    ${breakdown}=    Fetch Metrics Breakdown
+    ...    ?start=${METRICS_TEST_START}&end=${end}&group_by=service
+    ...    ${HEADERS2}
+    ${items}=    Get From Dictionary    ${breakdown}    items
+    ${contains_hidden_service}=    Evaluate
+    ...    any(item.get("key") == $INVOCATION_SERVICE_NAME for item in $items)
+    Should Be True
+    ...    not ${contains_hidden_service}
+    ...    msg=Metrics breakdown for the auxiliary user unexpectedly includes ${INVOCATION_SERVICE_NAME}
+
 
 *** Keywords ***
 Initialize Metrics Test Context
@@ -109,6 +141,18 @@ Initialize Metrics Test Context
     ...    datetime
     Set Suite Variable    ${METRICS_TEST_START}    ${start}
     Log    Metrics test range starts at ${METRICS_TEST_START}
+
+Ensure Auxiliary Metrics Authentication
+    [Documentation]    Ensure a second OIDC user is available for visibility checks.
+    Skip If    '${LOCAL_TESTING}'=='True'    Auxiliary OIDC authentication is not available in local testing.
+    ${has_headers2}=    Run Keyword And Return Status    Variable Should Exist    \${HEADERS2}
+    IF    not ${has_headers2}
+        ${has_multi_user_auth}=    Run Keyword And Return Status    Keyword Should Exist    Checks Valids OIDC Token
+        Skip If    not ${has_multi_user_auth}    Auxiliary authentication keyword is not available.
+        Checks Valids OIDC Token
+        ${has_headers2}=    Run Keyword And Return Status    Variable Should Exist    \${HEADERS2}
+        Skip If    not ${has_headers2}    Auxiliary authentication headers are not available.
+    END
 
 Ensure Invocation Service Ready
     [Documentation]    Create the sync/async test service if it is not already available.
@@ -186,6 +230,15 @@ Fetch System Metrics
     ${metrics}=    Evaluate    json.loads($response.content)    json
     Should Be True    isinstance($metrics, dict)    msg=Expected /system/metrics to return a JSON object
     RETURN    ${metrics}
+
+Fetch Metrics Breakdown
+    [Documentation]    Fetch /system/metrics/breakdown and return the decoded JSON body.
+    [Arguments]    ${query}=${EMPTY}    ${headers}=${HEADERS}
+    ${response}=    GET With Defaults    url=${OSCAR_ENDPOINT}/system/metrics/breakdown${query}    headers=${headers}
+    Log    ${response.content}
+    ${breakdown}=    Evaluate    json.loads($response.content)    json
+    Should Be True    isinstance($breakdown, dict)    msg=Expected /system/metrics/breakdown to return a JSON object
+    RETURN    ${breakdown}
 
 Fetch Service Metric
     [Documentation]    Fetch a single metric for a service within the integration test window.


### PR DESCRIPTION
## What changed

This adds a `system-metrics.robot` coverage case for cross-user service visibility.

The new test creates and invokes a private service with one OIDC user, then verifies that a second OIDC user:

- gets `403` when requesting `/system/metrics/{service}` for that hidden service
- does not see the hidden service in `/system/metrics/breakdown?group_by=service`

It also adds small helper keywords to fetch metrics breakdowns and to initialize auxiliary OIDC authentication only when the test actually needs it.

## Why

The OSCAR manager now scopes `/system/metrics` visibility for OIDC users. The test suite did not yet cover the regression case where one user must not see another user's private service metrics.

## Impact

This improves integration coverage for metrics authorization behavior without changing the product code.

## Validation

- `robot --dryrun -V variables/.env-auth-keycloak-gmolto.yaml -V variables/.env-cluster-localhost.yaml -d /tmp/robot-dryrun tests/api/system-metrics.robot`
- The full suite was also run locally before this fix; this patch corrects the failing assertion keyword in the new test.