### PR TITLE
docs: add venv setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,21 @@ Before running the tests, ensure you have the following tools installed:
 - [oscar-cli](https://github.com/grycap/oscar-cli)
 - [oscar-python](https://github.com/grycap/oscar_python/)
 
-To install the required dependencies:
+### 🐍 Using a Python Virtual Environment
 
+Create and activate a virtual environment before installing the Python dependencies:
+
+```sh
+python3 -m venv .venv
+source .venv/bin/activate
+python -m pip install --upgrade pip
+python -m pip install -r requirements.txt
 ```
-pip install -r requirements.txt
+
+When you finish working with the test suite, deactivate the environment:
+
+```sh
+deactivate
 ```
 
 ### 📦 Installing oscar-cli


### PR DESCRIPTION
## Summary

- Add README instructions for creating and activating a Python virtual environment.
- Document installing dependencies inside the venv and deactivating it afterwards.

## Validation

- Not run: documentation-only change.