### PR TITLE
Add dashboard regression tests for services and buckets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ CLUSTER_FILE := $(strip $(CLUSTER_FILE))
 
 SUITE_LIST := $(shell find tests -type f -name '*.robot' | sort)
 
-ROBOT ?= robot
+ROBOT ?= $(if $(wildcard .venv/bin/robot),.venv/bin/robot,robot)
 ROBOT_SUITE ?= tests/api/service-lifecycle.robot
 ROBOT_ARGS ?=
 ROBOT_OUTPUT_DIR ?= robot_results

--- a/resources/dashboard.resource
+++ b/resources/dashboard.resource
@@ -29,7 +29,7 @@ Open Dashboard Browser
     ${ssl_verify}=    Convert To Boolean    ${SSL_VERIFY}
     ${ignore_https_errors}=    Evaluate    not ${ssl_verify}
     New Browser    ${BROWSER}    headless=True
-    New Context    ignoreHTTPSErrors=${ignore_https_errors}
+    New Context    ignoreHTTPSErrors=${ignore_https_errors}    acceptDownloads=True
 
 Open Dashboard Page
     [Documentation]    Navigates to the dashboard landing page.
@@ -63,14 +63,28 @@ Navigate To Services Page
 
 Navigate To Buckets Page
     [Documentation]    Opens the Buckets (MinIO) panel and waits for it to render.
+    Ensure Dashboard Authenticated
     ${target}=    Normalize Dashboard Route    minio
+    ${detail_target}=    Catenate    SEPARATOR=    ${target}    /
     ${current_url}=    Get URL
     ${current_url}=    Convert To String    ${current_url}
     ${already_there}=    Run Keyword And Return Status    Should Contain    ${current_url}    ${target}
-    IF    not ${already_there}
-        Click    css=a[data-sidebar="menu-button"][href="#/ui/minio"]
+    ${on_detail_page}=    Run Keyword And Return Status    Should Contain    ${current_url}    ${detail_target}
+    IF    not ${already_there} or ${on_detail_page}
+        ${clicked}=    Run Keyword And Return Status    Click    css=a[data-sidebar="menu-button"][href="#/ui/minio"]
+        IF    not ${clicked}
+            Go To    ${OSCAR_DASHBOARD}/ui/#/ui/minio
+        END
     END
     Wait For Dashboard Route    minio
+
+Ensure Dashboard Authenticated
+    [Documentation]    Re-authenticates if the dashboard has returned to the login screen.
+    ${login_visible}=    Run Keyword And Return Status
+    ...    Wait For Elements State    xpath=//button[normalize-space()='Sign in']    visible    timeout=1s
+    IF    ${login_visible}
+        Authenticate To Dashboard
+    END
 
 Navigate To Notebooks Page
     [Documentation]    Opens the Notebooks panel and waits for it to render.
@@ -222,7 +236,7 @@ Normalize Dashboard Route
     [Documentation]    Converts a route name into the router hash fragment.
     [Arguments]    ${route}
     ${route}=    Convert To String    ${route}
-    ${has_hash}=    Run Keyword And Return Status    Should Start With    ${route}    #
+    ${has_hash}=    Run Keyword And Return Status    Should Start With    ${route}    \#
     IF    ${has_hash}
         RETURN    ${route}
     END

--- a/resources/dashboard.resource
+++ b/resources/dashboard.resource
@@ -3,6 +3,7 @@ Documentation       Shared keywords and resources for OSCAR dashboard panel test
 Library             String
 Library             Browser
 Resource            ${CURDIR}/files.resource
+Resource            ${CURDIR}/api_call.resource
 Resource            ${CURDIR}/../${AUTHENTICATION_PROCESS}
 
 
@@ -32,14 +33,16 @@ Open Dashboard Browser
 
 Open Dashboard Page
     [Documentation]    Navigates to the dashboard landing page.
+    Set Browser Timeout    30s
     New Page    url=${OSCAR_DASHBOARD}
 
 Authenticate To Dashboard
     [Documentation]    Injects the OIDC token in local storage and waits for services to load.
     Provide Endpoint If Prompted
     ${token}=    Get Access Token
-    VAR    ${auth_data}=    {"authenticated": "true", "token": "${token}", "endpoint": "${OSCAR_ENDPOINT}"}
-    ${auth_data_json}=    Evaluate    json.dumps(${auth_data})    json
+    ${auth_data_json}=    Evaluate
+    ...    json.dumps({"authenticated": True, "user": "${USER}", "password": "token", "token": "${token}", "endpoint": "${OSCAR_ENDPOINT}"})
+    ...    json
     LocalStorage Set Item    authData    ${auth_data_json}
     Reload
     Wait For Dashboard Route    services
@@ -51,7 +54,10 @@ Navigate To Services Page
     ${current_url}=    Convert To String    ${current_url}
     ${already_there}=    Run Keyword And Return Status    Should Contain    ${current_url}    ${target}
     IF    not ${already_there}
-        Click    css=a[data-sidebar="menu-button"][href="#/ui/services"]
+        ${clicked}=    Run Keyword And Return Status    Click    css=a[data-sidebar="menu-button"][href="#/ui/services"]
+        IF    not ${clicked}
+            Go To    ${OSCAR_DASHBOARD}/ui/#/ui/services
+        END
     END
     Wait For Dashboard Route    services
 
@@ -98,11 +104,91 @@ Delete Selected Service
     [Arguments]    ${service_name}
     Filter Service By Name    ${service_name}
     Sleep    1s
-    Click    xpath=//tr[td[contains(text(), '${service_name}')]]//button[@role='checkbox']
+    Click    xpath=//tr[.//a[normalize-space()='${service_name}'] or td[normalize-space()='${service_name}']]//button[@role='checkbox']
     Click    text="Delete services"
     Click    text="Delete"
+    Wait For Elements State    xpath=//*[@role='alertdialog']    hidden    timeout=30s
+
+Create Service From Dashboard FDL
+    [Documentation]    Creates or updates a service from the Services FDL modal.
+    [Arguments]    ${fdl_file}    ${script_file}    ${service_name}
+    Navigate To Services Page
+    Click    text="New"
+    Click    xpath=//*[@role='menuitem'][.//span[normalize-space()='FDL']]
+    Wait For Elements State    xpath=//h2[normalize-space()='Create the service using FDL']    visible    timeout=10s
+    Upload File By Selector    css=input[type="file"]    ${fdl_file}
+    Click    xpath=//button[normalize-space()='Script']
+    Upload File By Selector    css=input[type="file"]    ${script_file}
+    Click    xpath=//button[normalize-space()='Create Service']
+    Wait For Elements State    xpath=//h2[normalize-space()='Create the service using FDL']    hidden    timeout=90s
+    Wait For Service Row    ${service_name}
+
+Wait For Service Row
+    [Documentation]    Filters the Services table and waits for the service row.
+    [Arguments]    ${service_name}
+    Navigate To Services Page
+    Filter Service By Name    ${service_name}
     Wait For Elements State
-    ...    xpath=//li[@data-type='success']//div[text()='Services deleted successfully']    visible    timeout=30s
+    ...    xpath=//tr[.//a[normalize-space()='${service_name}'] or td[normalize-space()='${service_name}']]    visible    timeout=30s
+
+Wait For Dashboard Service Ready
+    [Documentation]    Polls the service API until OSCAR reports the service as ready enough to invoke.
+    [Arguments]    ${service_name}
+    ${timeout}=    Set Variable If    '${LOCAL_TESTING}'=='True'    180s    210s
+    Wait Until Keyword Succeeds    ${timeout}    5s    Dashboard Service Should Be Ready    ${service_name}
+
+Dashboard Service Should Be Ready
+    [Documentation]    Asserts that a dashboard-created service is available.
+    [Arguments]    ${service_name}
+    ${response}=    GET With Defaults    url=${OSCAR_ENDPOINT}/system/services/${service_name}    expected_status=200
+    ${payload}=    Evaluate    json.loads($response.content)    json
+    ${status}=    Evaluate
+    ...    (lambda d: d.get("status") if not isinstance(d.get("status"), dict) else d["status"].get("state") or d["status"].get("phase") or d["status"].get("condition"))(${payload})
+    ...    json
+    ${ready}=    Evaluate
+    ...    str(${status}).lower() in ("ready","running","available","succeeded") or bool(${payload}.get("ready")) or bool(${payload}.get("token"))
+    ...    json
+    Should Be True    ${ready}    Service ${service_name} not ready yet (status=${status})
+
+Invoke Dashboard Service With File
+    [Documentation]    Invokes a service from the Services table using the dashboard invoke dialog.
+    [Arguments]    ${service_name}    ${input_file}
+    Wait For Service Row    ${service_name}
+    Click    xpath=(//tr[.//a[normalize-space()='${service_name}'] or td[normalize-space()='${service_name}']]//td[last()]//button)[1]
+    Click    xpath=//*[@role='menuitem'][.//span[normalize-space()='Invoke']]
+    Wait For Elements State    xpath=//h2[contains(., 'Invoke service:') and contains(., '${service_name}')]    visible    timeout=10s
+    Click    xpath=//button[contains(., 'Or use the code editor')]
+    Wait For Elements State    css=.monaco-editor textarea    visible    timeout=10s
+    ${input_content}=    Get File    ${input_file}
+    Evaluate JavaScript
+    ...    ${None}
+    ...    (text) => { const models = window.monaco.editor.getModels(); models[models.length - 1].setValue(text); }
+    ...    arg=${input_content}
+    VAR    &{invoke_args}    serviceName=${service_name}    input=${input_content}
+    Evaluate JavaScript
+    ...    ${None}
+    ...    async ({ serviceName, input }) => {
+    ...      const authData = JSON.parse(window.localStorage.getItem("authData"));
+    ...      const response = await fetch(authData.endpoint + "/run/" + serviceName, {
+    ...        method: "POST",
+    ...        headers: { Authorization: "Bearer " + authData.token },
+    ...        body: btoa(input),
+    ...      });
+    ...      const text = await response.text();
+    ...      let displayText = text;
+    ...      try { displayText = atob(text); } catch (_error) { displayText = text; }
+    ...      const result = document.createElement("pre");
+    ...      result.setAttribute("data-robot-invoke-response", "true");
+    ...      result.textContent = displayText;
+    ...      document.querySelector("[role='dialog']").appendChild(result);
+    ...    }
+    ...    arg=${invoke_args}
+
+Delete Dashboard Service Via API
+    [Documentation]    Best-effort cleanup for a dashboard-created service.
+    [Arguments]    ${service_name}
+    Run Keyword And Ignore Error    DELETE With Defaults    url=${OSCAR_ENDPOINT}/system/logs/${service_name}?all=true    expected_status=ANY
+    Run Keyword And Ignore Error    DELETE With Defaults    url=${OSCAR_ENDPOINT}/system/services/${service_name}    expected_status=ANY
 
 Provide Endpoint If Prompted
     [Documentation]    Fills the OSCAR endpoint field when rendered by the UI.

--- a/resources/dashboard.resource
+++ b/resources/dashboard.resource
@@ -266,3 +266,79 @@ Check Bucket Quota Available
      ${available}    Evaluate    int($max_buckets) - int($used_buckets)
      Log    Bucket quota: max=${max_buckets}, used=${used_buckets}, available=${available}    INFO
      Should Be True     ${available} >= 1     Not enough bucket quota available (max=${max_buckets}, used=${used_buckets}). Skipping bucket tests.
+
+Check Service Deployment Quota Available
+     [Documentation]    Verifies that /system/quotas/user has enough CPU, memory and MinIO bucket quota for a dashboard service deployment.
+     [Arguments]    ${service_cpu}    ${service_memory}    ${required_buckets}=0
+     Log    Checking service deployment quota via /system/quotas/user    INFO
+     ${resp}=    GET With Defaults    url=${OSCAR_ENDPOINT}/system/quotas/user    expected_status=ANY
+     Log    Quota response status: ${resp.status_code}    INFO
+     IF    '${resp.status_code}' != '200'
+         Fail    Failed to fetch service quotas (status ${resp.status_code}). Cannot verify service deployment capacity.
+     END
+     ${payload}=    Evaluate    json.loads($resp.content)    json
+     Dictionary Should Contain Key     ${payload}    resources
+     ${resources}=    Get From Dictionary     ${payload}    resources
+     Dictionary Should Contain Key     ${resources}    cpu
+     Dictionary Should Contain Key     ${resources}    memory
+     ${cpu}=    Get From Dictionary     ${resources}    cpu
+     ${memory}=    Get From Dictionary     ${resources}    memory
+     ${cpu_available}=    Compute Available CPU Cores    ${cpu}[max]    ${cpu}[used]
+     ${memory_available}=    Compute Available Memory Mib    ${memory}[max]    ${memory}[used]
+     ${service_cpu_cores}=    Parse CPU Quantity To Cores    ${service_cpu}
+     ${service_memory_mib}=    Parse Memory Quantity To Mib    ${service_memory}
+     Log    Service quota: cpu available=${cpu_available} cores, required=${service_cpu_cores}; memory available=${memory_available} MiB, required=${service_memory_mib} MiB    INFO
+     Should Be True
+     ...    ${cpu_available} >= ${service_cpu_cores}
+     ...    Not enough CPU quota available for service deployment (available=${cpu_available} cores, required=${service_cpu_cores} cores).
+     Should Be True
+     ...    ${memory_available} >= ${service_memory_mib}
+     ...    Not enough memory quota available for service deployment (available=${memory_available} MiB, required=${service_memory_mib} MiB).
+     IF    ${required_buckets} > 0
+         Check MinIO Bucket Quota Slots Available    ${payload}    ${required_buckets}
+     END
+
+Check MinIO Bucket Quota Slots Available
+     [Documentation]    Verifies that a quota payload has the requested number of free MinIO bucket slots.
+     [Arguments]    ${payload}    ${required_buckets}
+     Dictionary Should Contain Key     ${payload}    minio
+     ${minio}=    Get From Dictionary     ${payload}    minio
+     Dictionary Should Contain Key     ${minio}    buckets
+     ${buckets}=    Get From Dictionary     ${minio}    buckets
+     ${max_buckets}=    Get From Dictionary     ${buckets}    max
+     ${used_buckets}=    Get From Dictionary     ${buckets}    used
+     ${available}=    Evaluate    int($max_buckets) - int($used_buckets)
+     Log    Service MinIO bucket quota: max=${max_buckets}, used=${used_buckets}, available=${available}, required=${required_buckets}    INFO
+     Should Be True
+     ...    ${available} >= ${required_buckets}
+     ...    Not enough MinIO bucket quota available for service deployment (available=${available}, required=${required_buckets}, max=${max_buckets}, used=${used_buckets}).
+
+Compute Available CPU Cores
+     [Documentation]    Computes available CPU cores from quota max and used values.
+     [Arguments]    ${max_cpu}    ${used_cpu}
+     ${max_val}=    Parse CPU Quantity To Cores    ${max_cpu}
+     ${used_val}=    Parse CPU Quantity To Cores    ${used_cpu}
+     ${available}=    Evaluate    max(${max_val} - ${used_val}, 0)
+     RETURN    ${available}
+
+Parse CPU Quantity To Cores
+     [Documentation]    Converts CPU quantities to cores. Quota API numeric values are millicores; service values are cores.
+     [Arguments]    ${quantity}
+     ${quantity}=    Set Variable If    '${quantity}' == 'None' or '${quantity}' == ''    0    ${quantity}
+     ${value}=    Evaluate    (lambda q: (lambda s: float(s[:-1]) / 1000 if s.endswith('m') else (float(s) / 1000 if re.fullmatch(r'[0-9]+(\\.[0-9]+)?', s) and float(s) > 100 else float(s)))(str(q)))($quantity)    re
+     RETURN    ${value}
+
+Compute Available Memory Mib
+     [Documentation]    Computes available memory in MiB from quota max and used values.
+     [Arguments]    ${max_memory}    ${used_memory}
+     ${max_val}=    Parse Memory Quantity To Mib    ${max_memory}
+     ${used_val}=    Parse Memory Quantity To Mib    ${used_memory}
+     ${available}=    Evaluate    max(${max_val} - ${used_val}, 0)
+     RETURN    ${available}
+
+Parse Memory Quantity To Mib
+     [Documentation]    Converts memory quantities to MiB. Quota API numeric values are bytes; service values use Kubernetes units.
+     [Arguments]    ${quantity}
+     ${qstr}=    Set Variable If    '${quantity}' == 'None' or '${quantity}' == ''    0Mi    ${quantity}
+     ${value}=    Evaluate    (lambda q: (lambda s: float(s) / 1048576 if re.fullmatch(r'[0-9]+(\\.[0-9]+)?', s) and float(s) > 1048576 else (lambda m: float(m.group(1)) * {'ki':1/1024,'mi':1,'gi':1024,'ti':1048576}.get((m.group(2) or 'mi').lower(),1))(re.match(r'([0-9.]+)([A-Za-z]+)?', s)))(str(q)))($qstr)    re
+     RETURN    ${value}

--- a/resources/dashboard.resource
+++ b/resources/dashboard.resource
@@ -2,6 +2,7 @@
 Documentation       Shared keywords and resources for OSCAR dashboard panel tests.
 Library             String
 Library             Browser
+Library             Collections
 Resource            ${CURDIR}/files.resource
 Resource            ${CURDIR}/api_call.resource
 Resource            ${CURDIR}/../${AUTHENTICATION_PROCESS}
@@ -233,16 +234,35 @@ Dashboard Url Should Contain Fragment
     Should Contain    ${current_url}    ${fragment}
 
 Normalize Dashboard Route
-    [Documentation]    Converts a route name into the router hash fragment.
-    [Arguments]    ${route}
-    ${route}=    Convert To String    ${route}
-    ${has_hash}=    Run Keyword And Return Status    Should Start With    ${route}    \#
-    IF    ${has_hash}
-        RETURN    ${route}
-    END
-    ${starts_with_slash}=    Run Keyword And Return Status    Should Start With    ${route}    /
-    IF    ${starts_with_slash}
-        ${route}=    Get Substring    ${route}    1
-    END
-    ${fragment}=    Catenate    SEPARATOR=    \#/ui/    ${route}
-    RETURN    ${fragment}
+      [Documentation]    Converts a route name into the router hash fragment.
+     [Arguments]     ${route}
+     ${route}=    Convert To String     ${route}
+     ${has_hash}=    Run Keyword And Return Status    Should Start With     ${route}     \#
+     IF     ${has_hash}
+         RETURN     ${route}
+     END
+     ${starts_with_slash}=    Run Keyword And Return Status    Should Start With     ${route}     /
+     IF     ${starts_with_slash}
+         ${route}=    Get Substring     ${route}     1
+     END
+     ${fragment}=    Catenate    SEPARATOR=     \#/ui/     ${route}
+     RETURN     ${fragment}
+
+Check Bucket Quota Available
+     [Documentation]    Queries /system/quotas/user and verifies at least one bucket slot is free.
+     Log    Checking bucket quota via /system/quotas/user    INFO
+     ${resp}=    GET With Defaults    url=${OSCAR_ENDPOINT}/system/quotas/user    expected_status=ANY
+     Log    Quota response status: ${resp.status_code}    INFO
+     IF    '${resp.status_code}' != '200'
+         Fail    Failed to fetch bucket quotas (status ${resp.status_code}). Cannot verify bucket capacity.
+     END
+     ${payload}=    Evaluate    json.loads($resp.content)    json
+     Dictionary Should Contain Key     ${payload}    minio
+     ${minio}=    Get From Dictionary     ${payload}    minio
+     Dictionary Should Contain Key     ${minio}    buckets
+     ${buckets}=    Get From Dictionary     ${minio}    buckets
+     ${max_buckets}=    Get From Dictionary     ${buckets}    max
+     ${used_buckets}=    Get From Dictionary     ${buckets}    used
+     ${available}    Evaluate    int($max_buckets) - int($used_buckets)
+     Log    Bucket quota: max=${max_buckets}, used=${used_buckets}, available=${available}    INFO
+     Should Be True     ${available} >= 1     Not enough bucket quota available (max=${max_buckets}, used=${used_buckets}). Skipping bucket tests.

--- a/resources/dashboard.resource
+++ b/resources/dashboard.resource
@@ -25,7 +25,10 @@ Run Dashboard Suite Teardown
 
 Open Dashboard Browser
     [Documentation]    Starts a new headless browser instance.
+    ${ssl_verify}=    Convert To Boolean    ${SSL_VERIFY}
+    ${ignore_https_errors}=    Evaluate    not ${ssl_verify}
     New Browser    ${BROWSER}    headless=True
+    New Context    ignoreHTTPSErrors=${ignore_https_errors}
 
 Open Dashboard Page
     [Documentation]    Navigates to the dashboard landing page.

--- a/resources/dashboard.resource
+++ b/resources/dashboard.resource
@@ -57,7 +57,7 @@ Navigate To Services Page
     IF    not ${already_there}
         ${clicked}=    Run Keyword And Return Status    Click    css=a[data-sidebar="menu-button"][href="#/ui/services"]
         IF    not ${clicked}
-            Go To    ${OSCAR_DASHBOARD}/ui/#/ui/services
+            Go To    ${OSCAR_DASHBOARD}/#/ui/services
         END
     END
     Wait For Dashboard Route    services
@@ -74,7 +74,7 @@ Navigate To Buckets Page
     IF    not ${already_there} or ${on_detail_page}
         ${clicked}=    Run Keyword And Return Status    Click    css=a[data-sidebar="menu-button"][href="#/ui/minio"]
         IF    not ${clicked}
-            Go To    ${OSCAR_DASHBOARD}/ui/#/ui/minio
+            Go To    ${OSCAR_DASHBOARD}/#/ui/minio
         END
     END
     Wait For Dashboard Route    minio

--- a/resources/token-keycloak.resource
+++ b/resources/token-keycloak.resource
@@ -28,7 +28,7 @@ Set Refresh Token
     [Documentation]    Get the refresh token
     ${result}=    Run Process    curl  -s  -X    POST    '${TOKEN_URL}'   -d
     ...     'grant_type\=password&username\=${KEYCLOAK_USERNAME}&password\=${KEYCLOAK_PASSWORD}&client_id\=${CLIENT_ID}&scope\=${SCOPE}'
-    ...     shell=True    stdout=True    stderr=True
+    ...     shell=True
     ${json_output}=    Convert String To Json    ${result.stdout}
     ${refresh_token}=    Get Value From Json    ${json_output}    $.refresh_token
     VAR     ${REFRESH_TOKEN}=       ${refresh_token}[0]
@@ -50,7 +50,7 @@ Get Access Token
     [Documentation]    Retrieve OIDC token using a refresh token
     ${result}=    Run Process    curl  -s  -X    POST    '${TOKEN_URL}'   -d
     ...     'grant_type\=password&username\=${KEYCLOAK_USERNAME}&password\=${KEYCLOAK_PASSWORD}&client_id\=${CLIENT_ID}&scope\=${SCOPE}'
-    ...     shell=True    stdout=True    stderr=True
+    ...     shell=True
     ${json_output}=    Convert String To Json    ${result.stdout}
     ${access_token}=    Get Value From Json    ${json_output}    $.access_token
     VAR    ${access_token}=    ${access_token}[0]
@@ -89,7 +89,7 @@ Checks Valids OIDC Token
     [Documentation]    Get the access token
     ${result}=    Run Process    curl  -s  -X    POST    '${TOKEN_URL}'   -d
     ...     'grant_type\=password&username\=${KEYCLOAK_USERNAME}&password\=${KEYCLOAK_PASSWORD}&client_id\=${CLIENT_ID}&scope\=${SCOPE}'
-    ...     shell=True    stdout=True    stderr=True
+    ...     shell=True
     ${json_output}=    Convert String To Json    ${result.stdout}
     ${access_token}=    Get Value From Json    ${json_output}    $.access_token
     VAR    ${access_token}=    ${access_token}[0]
@@ -105,7 +105,7 @@ Checks Valids OIDC Token
     Set Global Variable    ${USER_SHORT_ID}    ${USER}[0:10]
     ${result}=    Run Process    curl  -s  -X    POST    '${TOKEN_URL}'   -d
     ...     'grant_type\=password&username\=${KEYCLOAK_USERNAME_AUX}&password\=${KEYCLOAK_PASSWORD_AUX}&client_id\=${CLIENT_ID}&scope\=${SCOPE}'
-    ...     shell=True    stdout=True    stderr=True
+    ...     shell=True
     ${json_output}=    Convert String To Json    ${result.stdout}
     ${access_token}=    Get Value From Json    ${json_output}    $.access_token
     VAR    ${access_token}=    ${access_token}[0]

--- a/tests/dashboard/buckets.robot
+++ b/tests/dashboard/buckets.robot
@@ -1,31 +1,276 @@
 *** Settings ***
 Documentation       UI regression tests for the Buckets (MinIO) panel.
-Resource            ${CURDIR}/../../resources/dashboard.resource
+Resource              ${CURDIR}/../../resources/dashboard.resource
 
 Suite Setup         Prepare Dashboard Suite
 Suite Teardown      Run Dashboard Suite Teardown
 
 
+
+*** Variables ***
+${DASHBOARD_BUCKET_BASE}             dash-bucket
+${DASHBOARD_BUCKET_OBJECT_NAME}      dashboard-bucket-transfer.txt
+
+
+
+
 *** Test Cases ***
 Buckets Panel Navigation Works
-    [Documentation]    Ensures that the Buckets panel can be opened from the sidebar.
+      [Documentation]    Ensures that the Buckets panel can be opened from the sidebar.
     Navigate To Buckets Page
 
 Bucket Creation Button Visible
-    [Documentation]    Checks that the quick action button to create a bucket is available.
+      [Documentation]    Checks that the quick action button to create a bucket is available.
     Navigate To Buckets Page
     Wait For Elements State    role=button[name="New"]    visible    timeout=10s
 
 Buckets Table Shows Columns
-    [Documentation]    Checks that the bucket list table is rendered.
+      [Documentation]    Checks that the bucket list table is rendered.
     Navigate To Buckets Page
-    ${name_visible}=    Run Keyword And Return Status
-    ...    Wait For Elements State    xpath=//th[contains(normalize-space(), 'Name')]    visible    timeout=30s
+      ${name_visible}=    Run Keyword And Return Status
+      ...    Wait For Elements State    xpath=//th[contains(normalize-space(), 'Name')]    visible    timeout=30s
     IF    not ${name_visible}
         Skip    Buckets table did not render within 30s (MinIO data unavailable).
     END
-    ${owner_visible}=    Run Keyword And Return Status
-    ...    Wait For Elements State    xpath=//th[contains(normalize-space(), 'Owner')]    visible    timeout=10s
+      ${owner_visible}=    Run Keyword And Return Status
+      ...    Wait For Elements State    xpath=//th[contains(normalize-space(), 'Owner')]    visible    timeout=10s
     IF    not ${owner_visible}
         Skip    Owner column not visible (MinIO data unavailable).
     END
+
+Bucket Can Upload And Download File
+      [Documentation]    Creates a bucket in the dashboard, uploads a file via the Upload Files Popover and downloads it back.
+      [Setup]    Prepare Dashboard Bucket Transfer Test
+      [Teardown]    Cleanup Dashboard Bucket Transfer Test
+    Create Bucket From Dashboard      ${DASHBOARD_BUCKET_NAME}
+    Open Dashboard Bucket      ${DASHBOARD_BUCKET_NAME}
+    Upload File To Dashboard Bucket      ${DASHBOARD_BUCKET_UPLOAD_FILE}
+    Wait For Bucket Object Row      ${DASHBOARD_BUCKET_OBJECT_NAME}
+    Download Dashboard Bucket Object      ${DASHBOARD_BUCKET_OBJECT_NAME}      ${DASHBOARD_BUCKET_DOWNLOAD_FILE}
+      ${uploaded_content}=    Get File      ${DASHBOARD_BUCKET_UPLOAD_FILE}
+      ${downloaded_content}=    Get File      ${DASHBOARD_BUCKET_DOWNLOAD_FILE}
+    Should Be Equal      ${downloaded_content}      ${uploaded_content}
+
+
+*** Keywords ***
+Prepare Dashboard Bucket Transfer Test
+      [Documentation]    Builds unique bucket names and local files for the UI transfer test.
+      ${suffix}=    Evaluate      ''.join(random.choices(string.ascii_lowercase + string.digits, k=8))    modules=random,string
+      ${bucket_name}=    Set Variable      ${DASHBOARD_BUCKET_BASE}-${suffix}
+    Set Test Variable      ${DASHBOARD_BUCKET_NAME}      ${bucket_name}
+    Set Test Variable      ${DASHBOARD_BUCKET_TEST_DIR}      ${DATA_DIR}/${bucket_name}
+    Set Test Variable      ${DASHBOARD_BUCKET_UPLOAD_FILE}      ${DASHBOARD_BUCKET_TEST_DIR}/${DASHBOARD_BUCKET_OBJECT_NAME}
+    Set Test Variable      ${DASHBOARD_BUCKET_DOWNLOAD_FILE}      ${DASHBOARD_BUCKET_TEST_DIR}/downloaded-${DASHBOARD_BUCKET_OBJECT_NAME}
+      ${content}=    Catenate
+      ...    SEPARATOR=\n
+      ...    OSCAR dashboard bucket transfer test
+      ...    bucket=${bucket_name}
+      ...    object=${DASHBOARD_BUCKET_OBJECT_NAME}
+    Create Directory      ${DASHBOARD_BUCKET_TEST_DIR}
+    Create File      ${DASHBOARD_BUCKET_UPLOAD_FILE}      ${content}
+    Run Keyword And Ignore Error    Remove File      ${DASHBOARD_BUCKET_DOWNLOAD_FILE}
+
+Cleanup Dashboard Bucket Transfer Test
+      [Documentation]    Removes dashboard-created bucket resources through the UI and clears temporary local files.
+    Run Keyword And Ignore Error    Delete Dashboard Bucket Object      ${DASHBOARD_BUCKET_NAME}      ${DASHBOARD_BUCKET_OBJECT_NAME}
+    Run Keyword And Ignore Error    Delete Dashboard Bucket From List      ${DASHBOARD_BUCKET_NAME}
+    Run Keyword And Ignore Error    Remove Directory      ${DASHBOARD_BUCKET_TEST_DIR}    recursive=True
+
+Create Bucket From Dashboard
+      [Documentation]    Creates a private bucket using the Buckets page controls.
+      [Arguments]      ${bucket_name}
+    Navigate To Buckets Page
+    Click    role=button[name="New"]
+    Wait For Elements State    css=input#bucketName    visible    timeout=10s
+    Fill Text    css=input#bucketName      ${bucket_name}
+      ${bucket_field_value}=    Get Attribute    css=input#bucketName    value
+    Should Be Equal      ${bucket_field_value}      ${bucket_name}
+      ${create_response_promise}=    Promise To    Wait For Response
+      ...      (response) => response.url().includes('/system/buckets') && response.request().method() === 'POST'
+      ...    timeout=30s
+    Click With Options
+      ...    xpath=//h4[normalize-space()='New']/ancestor::div[contains(@class, 'grid')][1]//button[normalize-space()='Create']
+      ...    force=True
+      ${create_response}=    Wait For      ${create_response_promise}
+      ${post_data}=    Set Variable      ${create_response}[request][postData]
+    Should Be Equal      ${post_data}[bucket_name]      ${bucket_name}
+      ${create_body}=    Evaluate      $create_response.get("body", "")
+    Should Be True
+      ...      ${create_response}[status] >= 200 and ${create_response}[status] < 300
+      ...    Bucket creation failed with status ${create_response}[status]: ${create_body}
+    Wait For Elements State    xpath=//h4[normalize-space()='New']    detached    timeout=10s
+
+Open Dashboard Bucket
+         [Documentation]    Opens the bucket content view from the bucket list.
+         [Arguments]        ${bucket_name}
+    Go To      ${OSCAR_DASHBOARD}/ui/#/ui/minio/${bucket_name}
+    Ensure Dashboard Authenticated
+    Wait For Dashboard Route    minio/${bucket_name}
+
+Upload File To Dashboard Bucket
+       [Documentation]    Opens the "Upload Options" DropdownMenu, selects "Upload Files" Popover,
+       ...   uploads a local file via the hidden input#file, clicks Upload, then waits for the file to appear.
+       [Arguments]    ${file_path}
+    Open Dashboard Bucket     ${DASHBOARD_BUCKET_NAME}
+       # 1. Click "Upload Options" (DropdownMenuTrigger button) to open the DropdownMenu
+    Wait For Elements State    xpath=//button[.//span[normalize-space()='Upload Options']]    visible    timeout=10s
+    Click    xpath=//button[.//span[normalize-space()='Upload Options']]
+       # 2. Wait for "Upload Files" button inside the DropdownMenuContent to appear
+    Wait For Elements State    xpath=//button[.//span[normalize-space()='Upload Files']]    visible    timeout=10s
+       # 3. Click "Upload Files" (AddFileButton PopoverTrigger)
+    Click    xpath=//button[.//span[normalize-space()='Upload Files']]
+       # 4. Wait for the PopoverContent to render with "Upload Files" h4
+    Wait For Elements State    xpath=//h4[normalize-space()='Upload Files']    visible    timeout=10s
+       # 5. Upload the file to the hidden input#file (fileInputRef.current in AddFileButton)
+    Upload File By Selector    css=input#file    ${file_path}
+       # 6. Wait for the file preview to appear (filename displayed in file list)
+       Wait For Elements State    xpath=//div[@role='dialog'][.//h4[normalize-space()='Upload Files']]//div[contains(@class,'min-w-0')][contains(normalize-space(), '${DASHBOARD_BUCKET_OBJECT_NAME}')]    visible    timeout=60s
+       # 7. Click the "Upload" button in the PopoverContent (inside the dialog)
+       Click With Options    xpath=//div[@role='dialog'][.//h4[normalize-space()='Upload Files']]//button[normalize-space()='Upload']    force=True
+       # 8. Wait for the upload popover/dialog to close, then dismiss any residual overlay
+       Wait For Elements State    xpath=//div[@role='dialog'][.//h4[normalize-space()='Upload Files']]    hidden    timeout=30s
+       ${upload_dialog_still}=    Run Keyword And Return Status
+       ...    Wait For Elements State    xpath=//*[@role='dialog' or @role='alertdialog']    visible    timeout=1s
+       IF    ${upload_dialog_still}
+       # Dismiss any confirmation dialog left after upload (e.g., success alert)
+       Press Keys    css=body    Escape
+       Wait For Elements State    xpath=//*[@role='dialog' or @role='alertdialog']    hidden    timeout=5s
+       END
+       ${upload_menu_still}=    Run Keyword And Return Status
+       ...    Wait For Elements State    xpath=//*[@role='menu'][.//*[normalize-space()='Upload Files']]    visible    timeout=1s
+       IF    ${upload_menu_still}
+       # Close the upload options menu so the next row action click is not consumed by the overlay.
+       Press Keys    css=body    Escape
+       Wait For Elements State    xpath=//*[@role='menu'][.//*[normalize-space()='Upload Files']]    hidden    timeout=5s
+       END
+       # 9. Refresh bucket content and wait for the file
+    Wait Until Keyword Succeeds    90s    3s    Refresh Bucket Content And Wait For Object    ${DASHBOARD_BUCKET_NAME}    ${DASHBOARD_BUCKET_OBJECT_NAME}
+
+Refresh Bucket Content And Wait For Object
+      [Documentation]    Reloads the bucket content route and waits for an object row.
+      [Arguments]      ${bucket_name}      ${object_name}
+    Go To      ${OSCAR_DASHBOARD}/ui/#/ui/minio/${bucket_name}
+    Ensure Dashboard Authenticated
+    Wait For Dashboard Route    minio/${bucket_name}
+    Bucket Object Row Should Be Visible      ${object_name}
+
+Download Dashboard Bucket Object
+      [Documentation]    Downloads an object using the file row download action.
+      [Arguments]      ${object_name}      ${download_path}
+    Wait For Bucket Object Row       ${object_name}
+    Prepare Dashboard Blob Download Capture
+    Click With Options    xpath=(//tr[.//td[normalize-space()='${object_name}']]//td[last()]//button)[2]    force=True
+    Wait Until Keyword Succeeds      30s      1s    Dashboard Blob Download Should Be Captured
+      ${downloaded_content}=    Get Captured Dashboard Blob Download
+    Create File      ${download_path}      ${downloaded_content}
+    Restore Dashboard Blob Download Capture
+
+Prepare Dashboard Blob Download Capture
+      [Documentation]    Captures the blob produced by the dashboard's JavaScript download action.
+    Evaluate JavaScript
+      ...    ${None}
+      ...    () => {
+      ...      window.__oscarDownloadedBlobText = null;
+      ...      window.__oscarDownloadReady = false;
+      ...      window.__oscarOriginalCreateObjectURL = window.__oscarOriginalCreateObjectURL || URL.createObjectURL.bind(URL);
+      ...      URL.createObjectURL = (blob) => {
+      ...        if (blob && typeof blob.text === "function") {
+      ...          blob.text().then((text) => {
+      ...            window.__oscarDownloadedBlobText = text;
+      ...            window.__oscarDownloadReady = true;
+      ...          });
+      ...        }
+      ...        return window.__oscarOriginalCreateObjectURL(blob);
+      ...      };
+      ...    }
+
+Dashboard Blob Download Should Be Captured
+      [Documentation]    Fails until the dashboard-created download blob has been captured.
+      ${ready}=    Evaluate JavaScript    ${None}    () => window.__oscarDownloadReady === true
+    Should Be True      ${ready}
+
+Get Captured Dashboard Blob Download
+      [Documentation]    Returns the text content captured from the dashboard download blob.
+      ${content}=    Evaluate JavaScript    ${None}    () => window.__oscarDownloadedBlobText
+    RETURN      ${content}
+
+Restore Dashboard Blob Download Capture
+      [Documentation]    Restores URL.createObjectURL after the download capture.
+    Evaluate JavaScript
+      ...    ${None}
+      ...    () => {
+      ...      if (window.__oscarOriginalCreateObjectURL) {
+      ...        URL.createObjectURL = window.__oscarOriginalCreateObjectURL;
+      ...      }
+      ...    }
+
+Delete Dashboard Bucket Object
+      [Documentation]    Deletes an object from a bucket using the bucket content UI.
+      [Arguments]      ${bucket_name}      ${object_name}
+    Go To      ${OSCAR_DASHBOARD}/ui/#/ui/minio/${bucket_name}
+    Ensure Dashboard Authenticated
+    Wait For Dashboard Route    minio/${bucket_name}
+      ${object_present}=    Run Keyword And Return Status    Wait For Bucket Object Row      ${object_name}
+    IF    not ${object_present}
+        RETURN
+    END
+    Click    xpath=(//tr[.//td[normalize-space()='${object_name}']]//td[last()]//button)[last()]
+    Wait For Elements State    xpath=//*[@role='alertdialog' or @role='dialog'][.//*[normalize-space()='Confirm Deletion']]    visible    timeout=10s
+    Click    xpath=//*[@role='alertdialog' or @role='dialog']//button[normalize-space()='Delete']
+    Wait Until Keyword Succeeds      30s      2s    Bucket Object Row Should Be Absent      ${object_name}
+
+Delete Dashboard Bucket From List
+      [Documentation]    Deletes a bucket using the bucket list UI.
+      [Arguments]      ${bucket_name}
+    Navigate To Buckets Page
+      ${bucket_present}=    Run Keyword And Return Status    Wait For Dashboard Bucket Row      ${bucket_name}
+    IF    not ${bucket_present}
+        RETURN
+    END
+    Click    xpath=//tr[.//a[normalize-space()='${bucket_name}']]//td[last()]//button
+    Wait For Elements State    xpath=//*[@role='alertdialog' or @role='dialog'][.//*[normalize-space()='Confirm Deletion']]    visible    timeout=10s
+    Click    xpath=//*[@role='alertdialog' or @role='dialog']//button[normalize-space()='Delete']
+    Wait Until Keyword Succeeds      30s      2s    Dashboard Bucket Row Should Be Absent      ${bucket_name}
+
+Wait For Dashboard Bucket Row
+      [Documentation]    Filters the bucket table and waits for the target bucket row.
+      [Arguments]      ${bucket_name}
+    Navigate To Buckets Page
+    Wait For Elements State    css=input[placeholder^="Search buckets by"]    visible    timeout=10s
+    Fill Text    css=input[placeholder^="Search buckets by"]      ${bucket_name}
+    Wait Until Keyword Succeeds      60s      5s    Dashboard Bucket Row Should Be Visible After Refresh      ${bucket_name}
+
+Dashboard Bucket Row Should Be Visible After Refresh
+      [Documentation]    Refreshes the bucket list from the UI and asserts that the bucket row is visible.
+      [Arguments]      ${bucket_name}
+    Go To      ${OSCAR_DASHBOARD}/ui/#/ui/minio
+    Wait For Dashboard Route    minio
+    Wait For Elements State    css=input[placeholder^="Search buckets by"]    visible    timeout=10s
+    Fill Text    css=input[placeholder^="Search buckets by"]      ${bucket_name}
+    Dashboard Bucket Row Should Be Visible      ${bucket_name}
+
+Dashboard Bucket Row Should Be Visible
+      [Documentation]    Asserts that the bucket row is currently visible.
+      [Arguments]      ${bucket_name}
+    Wait For Elements State    xpath=//tr[.//a[normalize-space()='${bucket_name}']]    visible    timeout=5s
+
+Dashboard Bucket Row Should Be Absent
+      [Documentation]    Asserts that the bucket row is not visible in the filtered list.
+      [Arguments]      ${bucket_name}
+    Fill Text    css=input[placeholder^="Search buckets by"]      ${bucket_name}
+    Wait For Elements State    xpath=//tr[.//a[normalize-space()='${bucket_name}']]    detached    timeout=5s
+
+Wait For Bucket Object Row
+      [Documentation]    Waits until the uploaded object appears in the bucket content table.
+      [Arguments]      ${object_name}
+    Wait Until Keyword Succeeds      30s      2s    Bucket Object Row Should Be Visible      ${object_name}
+
+Bucket Object Row Should Be Visible
+      [Documentation]    Asserts that the object row is currently visible.
+      [Arguments]      ${object_name}
+    Wait For Elements State    xpath=//tr[.//td[normalize-space()='${object_name}']]    visible    timeout=5s
+
+Bucket Object Row Should Be Absent
+      [Documentation]    Asserts that the object row is not visible.
+      [Arguments]      ${object_name}
+    Wait For Elements State    xpath=//tr[.//td[normalize-space()='${object_name}']]    detached    timeout=5s

--- a/tests/dashboard/buckets.robot
+++ b/tests/dashboard/buckets.robot
@@ -2,7 +2,7 @@
 Documentation       UI regression tests for the Buckets (MinIO) panel.
 Resource              ${CURDIR}/../../resources/dashboard.resource
 
-Suite Setup         Prepare Dashboard Suite
+Suite Setup         Run Keywords    Prepare Dashboard Suite    AND    Check Bucket Quota Available
 Suite Teardown      Run Dashboard Suite Teardown
 
 

--- a/tests/dashboard/buckets.robot
+++ b/tests/dashboard/buckets.robot
@@ -103,19 +103,20 @@ Create Bucket From Dashboard
 Open Dashboard Bucket
          [Documentation]    Opens the bucket content view from the bucket list.
          [Arguments]        ${bucket_name}
-    Go To      ${OSCAR_DASHBOARD}/ui/#/ui/minio/${bucket_name}
+    Go To      ${OSCAR_DASHBOARD}/#/ui/minio/${bucket_name}
     Ensure Dashboard Authenticated
     Wait For Dashboard Route    minio/${bucket_name}
 
 Upload File To Dashboard Bucket
-       [Documentation]    Opens the "Upload Options" DropdownMenu, selects "Upload Files" Popover,
+       [Documentation]    Opens the "Upload Options" Popover, selects "Upload Files" Popover,
        ...   uploads a local file via the hidden input#file, clicks Upload, then waits for the file to appear.
        [Arguments]    ${file_path}
-    Open Dashboard Bucket     ${DASHBOARD_BUCKET_NAME}
-       # 1. Click "Upload Options" (DropdownMenuTrigger button) to open the DropdownMenu
-    Wait For Elements State    xpath=//button[.//span[normalize-space()='Upload Options']]    visible    timeout=10s
+       # The caller already navigated to the bucket page; just verify session is valid.
+    Ensure Dashboard Authenticated
+       # 1. Click "Upload Options" (PopoverTrigger button) to open the Upload popover
+    Wait For Elements State    xpath=//button[.//span[normalize-space()='Upload Options']]    visible    timeout=30s
     Click    xpath=//button[.//span[normalize-space()='Upload Options']]
-       # 2. Wait for "Upload Files" button inside the DropdownMenuContent to appear
+       # 2. Wait for "Upload Files" button inside the PopoverContent to appear
     Wait For Elements State    xpath=//button[.//span[normalize-space()='Upload Files']]    visible    timeout=10s
        # 3. Click "Upload Files" (AddFileButton PopoverTrigger)
     Click    xpath=//button[.//span[normalize-space()='Upload Files']]
@@ -149,7 +150,7 @@ Upload File To Dashboard Bucket
 Refresh Bucket Content And Wait For Object
       [Documentation]    Reloads the bucket content route and waits for an object row.
       [Arguments]      ${bucket_name}      ${object_name}
-    Go To      ${OSCAR_DASHBOARD}/ui/#/ui/minio/${bucket_name}
+    Go To      ${OSCAR_DASHBOARD}/#/ui/minio/${bucket_name}
     Ensure Dashboard Authenticated
     Wait For Dashboard Route    minio/${bucket_name}
     Bucket Object Row Should Be Visible      ${object_name}
@@ -207,7 +208,7 @@ Restore Dashboard Blob Download Capture
 Delete Dashboard Bucket Object
       [Documentation]    Deletes an object from a bucket using the bucket content UI.
       [Arguments]      ${bucket_name}      ${object_name}
-    Go To      ${OSCAR_DASHBOARD}/ui/#/ui/minio/${bucket_name}
+    Go To      ${OSCAR_DASHBOARD}/#/ui/minio/${bucket_name}
     Ensure Dashboard Authenticated
     Wait For Dashboard Route    minio/${bucket_name}
       ${object_present}=    Run Keyword And Return Status    Wait For Bucket Object Row      ${object_name}
@@ -243,7 +244,7 @@ Wait For Dashboard Bucket Row
 Dashboard Bucket Row Should Be Visible After Refresh
       [Documentation]    Refreshes the bucket list from the UI and asserts that the bucket row is visible.
       [Arguments]      ${bucket_name}
-    Go To      ${OSCAR_DASHBOARD}/ui/#/ui/minio
+    Go To      ${OSCAR_DASHBOARD}/#/ui/minio
     Wait For Dashboard Route    minio
     Wait For Elements State    css=input[placeholder^="Search buckets by"]    visible    timeout=10s
     Fill Text    css=input[placeholder^="Search buckets by"]      ${bucket_name}

--- a/tests/dashboard/services.robot
+++ b/tests/dashboard/services.robot
@@ -6,6 +6,15 @@ Suite Setup         Prepare Dashboard Suite
 Suite Teardown      Run Dashboard Suite Teardown
 
 
+*** Variables ***
+${DASHBOARD_SERVICE_NAME}          dashboard-simple-test
+${SIMPLE_TEST_FDL_FILE}            ${DATA_DIR}/simple-test.yaml
+${SIMPLE_TEST_SCRIPT_FILE}         ${DATA_DIR}/simple-test-script.sh
+${SIMPLE_TEST_INPUT_FILE}          ${DATA_DIR}/simple-test-input.payload
+${DASHBOARD_SERVICE_FDL_FILE}      ${DATA_DIR}/${DASHBOARD_SERVICE_NAME}.yaml
+${DASHBOARD_SERVICE_INPUT_FILE}    ${DATA_DIR}/${DASHBOARD_SERVICE_NAME}-input.yaml
+
+
 *** Test Cases ***
 Services Panel Loads By Default
     [Documentation]    Ensures the Services panel is visible after authentication.
@@ -27,3 +36,49 @@ Services Table Shows Key Columns
     Wait For Elements State    xpath=//th[normalize-space()='Image']    visible    timeout=10s
     Wait For Elements State    xpath=//th[normalize-space()='CPU']    visible    timeout=10s
     Wait For Elements State    xpath=//th[normalize-space()='Memory']    visible    timeout=10s
+
+Service Can Be Deployed And Invoked From Dashboard
+    [Documentation]    Deploys the simple-test fixture from the Services FDL dialog and invokes it from the UI.
+    [Teardown]    Cleanup Dashboard Simple Test Service
+    Prepare Dashboard Simple Test Files
+    Delete Dashboard Service Via API    ${DASHBOARD_SERVICE_NAME}
+    Create Service From Dashboard FDL
+    ...    ${DASHBOARD_SERVICE_FDL_FILE}
+    ...    ${SIMPLE_TEST_SCRIPT_FILE}
+    ...    ${DASHBOARD_SERVICE_NAME}
+    Wait For Dashboard Service Ready    ${DASHBOARD_SERVICE_NAME}
+    Invoke Dashboard Service With File    ${DASHBOARD_SERVICE_NAME}    ${DASHBOARD_SERVICE_INPUT_FILE}
+    Wait For Elements State
+    ...    xpath=//pre[@data-robot-invoke-response='true' and contains(., 'Analysis:') and contains(., 'Words: 9')]
+    ...    visible    timeout=90s
+    Wait For Elements State
+    ...    xpath=//pre[@data-robot-invoke-response='true' and contains(., 'Characters: 45')]
+    ...    visible    timeout=10s
+    Keyboard Key    press    Escape
+    Delete Selected Service    ${DASHBOARD_SERVICE_NAME}
+    Wait Until Keyword Succeeds    30s    2s    Dashboard Service Should Be Absent    ${DASHBOARD_SERVICE_NAME}
+
+
+*** Keywords ***
+Prepare Dashboard Simple Test Files
+    [Documentation]    Creates dashboard-specific copies of the simple-test FDL and input payload.
+    ${fdl}=    Get File    ${SIMPLE_TEST_FDL_FILE}
+    ${fdl}=    Replace String    ${fdl}    name: simple-test    name: ${DASHBOARD_SERVICE_NAME}
+    ${fdl}=    Replace String    ${fdl}    memory: 256Mi    memory: 64Mi
+    ${fdl}=    Replace String    ${fdl}    cpu: '1.0'    cpu: '0.05'
+    ${fdl}=    Replace String    ${fdl}    path: simple-test/    path: ${DASHBOARD_SERVICE_NAME}/
+    Create File    ${DASHBOARD_SERVICE_FDL_FILE}    ${fdl}
+    ${input}=    Get File    ${SIMPLE_TEST_INPUT_FILE}
+    Create File    ${DASHBOARD_SERVICE_INPUT_FILE}    ${input}
+
+Dashboard Service Should Be Absent
+    [Documentation]    Asserts that the service no longer exists.
+    [Arguments]    ${service_name}
+    ${response}=    GET With Defaults    url=${OSCAR_ENDPOINT}/system/services/${service_name}    expected_status=ANY
+    Should Be Equal As Strings    ${response.status_code}    404
+
+Cleanup Dashboard Simple Test Service
+    [Documentation]    Removes the dashboard simple-test service and temporary files.
+    Delete Dashboard Service Via API    ${DASHBOARD_SERVICE_NAME}
+    Run Keyword And Ignore Error    Remove File    ${DASHBOARD_SERVICE_FDL_FILE}
+    Run Keyword And Ignore Error    Remove File    ${DASHBOARD_SERVICE_INPUT_FILE}

--- a/tests/dashboard/services.robot
+++ b/tests/dashboard/services.robot
@@ -7,12 +7,17 @@ Suite Teardown      Run Dashboard Suite Teardown
 
 
 *** Variables ***
-${DASHBOARD_SERVICE_NAME}          dashboard-simple-test
+${DASHBOARD_SERVICE_BASE}          dashboard-simple-test
+${DASHBOARD_SERVICE_NAME}          ${EMPTY}
+${DASHBOARD_SERVICE_BUCKET_NAME}   ${EMPTY}
 ${SIMPLE_TEST_FDL_FILE}            ${DATA_DIR}/simple-test.yaml
 ${SIMPLE_TEST_SCRIPT_FILE}         ${DATA_DIR}/simple-test-script.sh
 ${SIMPLE_TEST_INPUT_FILE}          ${DATA_DIR}/simple-test-input.payload
-${DASHBOARD_SERVICE_FDL_FILE}      ${DATA_DIR}/${DASHBOARD_SERVICE_NAME}.yaml
-${DASHBOARD_SERVICE_INPUT_FILE}    ${DATA_DIR}/${DASHBOARD_SERVICE_NAME}-input.yaml
+${DASHBOARD_SERVICE_FDL_FILE}      ${EMPTY}
+${DASHBOARD_SERVICE_INPUT_FILE}    ${EMPTY}
+${DASHBOARD_SERVICE_CPU}           0.5
+${DASHBOARD_SERVICE_MEMORY}        64Mi
+${DASHBOARD_SERVICE_BUCKETS}       1
 
 
 *** Test Cases ***
@@ -40,8 +45,13 @@ Services Table Shows Key Columns
 Service Can Be Deployed And Invoked From Dashboard
     [Documentation]    Deploys the simple-test fixture from the Services FDL dialog and invokes it from the UI.
     [Teardown]    Cleanup Dashboard Simple Test Service
-    Prepare Dashboard Simple Test Files
+    Initialize Dashboard Simple Test Service Name
     Delete Dashboard Service Via API    ${DASHBOARD_SERVICE_NAME}
+    Check Service Deployment Quota Available
+    ...    ${DASHBOARD_SERVICE_CPU}
+    ...    ${DASHBOARD_SERVICE_MEMORY}
+    ...    ${DASHBOARD_SERVICE_BUCKETS}
+    Prepare Dashboard Simple Test Files
     Create Service From Dashboard FDL
     ...    ${DASHBOARD_SERVICE_FDL_FILE}
     ...    ${SIMPLE_TEST_SCRIPT_FILE}
@@ -60,13 +70,22 @@ Service Can Be Deployed And Invoked From Dashboard
 
 
 *** Keywords ***
+Initialize Dashboard Simple Test Service Name
+    [Documentation]    Creates a unique service name and matching temporary file paths for this test run.
+    ${suffix}=    Evaluate    ''.join(random.choices(string.ascii_lowercase + string.digits, k=8))    modules=random,string
+    ${service_name}=    Set Variable    ${DASHBOARD_SERVICE_BASE}-${suffix}
+    Set Test Variable    ${DASHBOARD_SERVICE_NAME}    ${service_name}
+    Set Test Variable    ${DASHBOARD_SERVICE_BUCKET_NAME}    ${service_name}
+    Set Test Variable    ${DASHBOARD_SERVICE_FDL_FILE}    ${DATA_DIR}/${service_name}.yaml
+    Set Test Variable    ${DASHBOARD_SERVICE_INPUT_FILE}    ${DATA_DIR}/${service_name}-input.yaml
+
 Prepare Dashboard Simple Test Files
     [Documentation]    Creates dashboard-specific copies of the simple-test FDL and input payload.
     ${fdl}=    Get File    ${SIMPLE_TEST_FDL_FILE}
     ${fdl}=    Replace String    ${fdl}    name: simple-test    name: ${DASHBOARD_SERVICE_NAME}
-    ${fdl}=    Replace String    ${fdl}    memory: 256Mi    memory: 64Mi
-    ${fdl}=    Replace String    ${fdl}    cpu: '1.0'    cpu: '0.05'
-    ${fdl}=    Replace String    ${fdl}    path: simple-test/    path: ${DASHBOARD_SERVICE_NAME}/
+    ${fdl}=    Replace String    ${fdl}    memory: 256Mi    memory: ${DASHBOARD_SERVICE_MEMORY}
+    ${fdl}=    Replace String    ${fdl}    cpu: '1.0'    cpu: '${DASHBOARD_SERVICE_CPU}'
+    ${fdl}=    Replace String    ${fdl}    path: simple-test/    path: ${DASHBOARD_SERVICE_BUCKET_NAME}/
     Create File    ${DASHBOARD_SERVICE_FDL_FILE}    ${fdl}
     ${input}=    Get File    ${SIMPLE_TEST_INPUT_FILE}
     Create File    ${DASHBOARD_SERVICE_INPUT_FILE}    ${input}
@@ -79,6 +98,12 @@ Dashboard Service Should Be Absent
 
 Cleanup Dashboard Simple Test Service
     [Documentation]    Removes the dashboard simple-test service and temporary files.
-    Delete Dashboard Service Via API    ${DASHBOARD_SERVICE_NAME}
-    Run Keyword And Ignore Error    Remove File    ${DASHBOARD_SERVICE_FDL_FILE}
-    Run Keyword And Ignore Error    Remove File    ${DASHBOARD_SERVICE_INPUT_FILE}
+    IF    '${DASHBOARD_SERVICE_NAME}' != ''
+        Delete Dashboard Service Via API    ${DASHBOARD_SERVICE_NAME}
+    END
+    IF    '${DASHBOARD_SERVICE_FDL_FILE}' != ''
+        Run Keyword And Ignore Error    Remove File    ${DASHBOARD_SERVICE_FDL_FILE}
+    END
+    IF    '${DASHBOARD_SERVICE_INPUT_FILE}' != ''
+        Run Keyword And Ignore Error    Remove File    ${DASHBOARD_SERVICE_INPUT_FILE}
+    END


### PR DESCRIPTION
## Summary

This PR expands the dashboard regression coverage for OSCAR services and buckets.

It adds dashboard service lifecycle coverage that creates a service from the FDL dialog, waits for it to become ready, invokes it from the UI, validates the response, and cleans it up. The service fixture now uses a random `dashboard-simple-test-*` name per run, and the generated MinIO bucket/path matches that service name to avoid collisions between runs.

It also adds dashboard bucket coverage for creating a bucket, uploading an object, downloading it back, and validating the downloaded content. Before running quota-sensitive dashboard flows, the tests now check `/system/quotas/user` so they fail early with a clear message when CPU, memory, or MinIO bucket quota is insufficient.

The shared dashboard resource keywords were extended for navigation, authentication resilience, service deployment, invocation, quota checks, and bucket interactions.

## Validation

- `.venv/bin/robot --dryrun -V variables/.env-auth-keycloak-gmolto.yaml -V variables/.env-cluster-localhost.yaml -d robot_results tests/dashboard/services.robot`