### PR TITLE
Fix local bucket API tests

### DIFF
--- a/resources/files.resource
+++ b/resources/files.resource
@@ -195,5 +195,5 @@ Set Service File For Update
 
 Verify Bucket
     [Documentation]    List all buckets
-    ${response}=    GET    url=${OSCAR_ENDPOINT}/system/buckets    expected_status=200    headers=${HEADERS}
+    ${response}=    GET    url=${OSCAR_ENDPOINT}/system/buckets    expected_status=200    headers=${HEADERS}    verify=${SSL_VERIFY}
     RETURN      ${response}

--- a/tests/api/bucket-presign.robot
+++ b/tests/api/bucket-presign.robot
@@ -5,6 +5,7 @@ Library             Collections
 Resource            ${CURDIR}/../../${AUTHENTICATION_PROCESS}
 Resource            ${CURDIR}/../../resources/files.resource
 Resource            ${CURDIR}/../../resources/api_call.resource
+Resource            ${CURDIR}/../../resources/service.resource
 
 Suite Setup         Run Keywords    Check Valid OIDC Token    AND    Initialize Presign Test Names
 Suite Teardown      Cleanup Presign Test Artifacts
@@ -18,6 +19,9 @@ ${BUCKET_CONFIG_FILE}   ${DATA_DIR}/bucket.json
 OSCAR Create Bucket For Presign
     [Documentation]    Create a bucket to test presigned URL generation.
     ${body}=    Get File    ${BUCKET_CONFIG_FILE}
+    ${payload}=    Evaluate    json.loads($body)    json
+    Set To Dictionary    ${payload}    bucket_name=${bucket_name}
+    ${body}=    Evaluate    json.dumps($payload)    json
     ${response}=    POST With Defaults    url=${OSCAR_ENDPOINT}/system/buckets    data=${body}
     Log    ${response.content}
     Should Be Equal As Strings    ${response.status_code}    201
@@ -60,9 +64,10 @@ OSCAR Presign Bucket Not Found
 
 *** Keywords ***
 Initialize Presign Test Names
-    [Documentation]    Use the default bucket name from the bucket config file.
+    [Documentation]    Generate an isolated bucket name from the configured base name.
     ${content}=    Get File    ${BUCKET_CONFIG_FILE}
-    ${bucket_name}=    Evaluate    json.loads($content).get("bucket_name", "robot-test")    json
+    ${bucket_base}=    Evaluate    json.loads($content).get("bucket_name", "robot-test")    json
+    ${bucket_name}=    Generate Random Service Name    ${bucket_base}
     Set Suite Variable    ${bucket_name}    ${bucket_name}
 
 Create Presign Payload

--- a/tests/api/buckets.robot
+++ b/tests/api/buckets.robot
@@ -15,7 +15,7 @@ ${bucket_name}    robot-test
 *** Test Cases ***
 OSCAR API Health
     [Documentation]    Check API health
-    ${response}=    GET  ${OSCAR_ENDPOINT}/health  expected_status=200
+    ${response}=    GET  ${OSCAR_ENDPOINT}/health  expected_status=200    verify=${SSL_VERIFY}
     Log    ${response.content}
     Should Be Equal As Strings    ${response.content}    Ok
 
@@ -24,7 +24,7 @@ Create Bucket Private
     [Tags]    create    bucket
     ${body}=    Get File    ${DATA_DIR}/bucket.json
     ${response}=    POST    url=${OSCAR_ENDPOINT}/system/buckets    expected_status=201    data=${body}
-    ...    headers=${HEADERS}
+    ...    headers=${HEADERS}    verify=${SSL_VERIFY}
     Log    ${response.content}
     Should Be Equal As Strings    ${response.status_code}    201
 
@@ -43,7 +43,7 @@ Update Bucket from Private -> to Restricted
     ${body}=    Set Bucket File Allowed Users   ${body}     ${USER}
     ${body}= 	Convert JSON To String 	${body}
     ${response}=    PUT    url=${OSCAR_ENDPOINT}/system/buckets    expected_status=204    data=${body}
-    ...    headers=${HEADERS}
+    ...    headers=${HEADERS}    verify=${SSL_VERIFY}
     Log    ${response.content}
     Should Be Equal As Strings    ${response.status_code}    204
 
@@ -61,7 +61,7 @@ Update Bucket from Restricted -> to Public
     ${body}=    Set Bucket File Visibility      ${body}     public
     ${body}= 	Convert JSON To String 	${body}
     ${response}=    PUT    url=${OSCAR_ENDPOINT}/system/buckets    expected_status=204    data=${body}
-    ...    headers=${HEADERS}
+    ...    headers=${HEADERS}    verify=${SSL_VERIFY}
     Log    ${response.content}
     Should Be Equal As Strings    ${response.status_code}    204
 
@@ -78,7 +78,7 @@ Update Bucket from Public -> to Private
     [Tags]    update    bucket
     ${body}=    Get File    ${DATA_DIR}/bucket.json
     ${response}=    PUT    url=${OSCAR_ENDPOINT}/system/buckets    expected_status=204    data=${body}
-    ...    headers=${HEADERS}
+    ...    headers=${HEADERS}    verify=${SSL_VERIFY}
     Log    ${response.content}
     Should Be Equal As Strings    ${response.status_code}    204
 
@@ -98,7 +98,7 @@ Update Bucket from Private -> to Public
     ${body}=    Set Bucket File Visibility      ${body}     public
     ${body}= 	Convert JSON To String 	${body}
     ${response}=    PUT    url=${OSCAR_ENDPOINT}/system/buckets    expected_status=204    data=${body}
-    ...    headers=${HEADERS}
+    ...    headers=${HEADERS}    verify=${SSL_VERIFY}
     Log    ${response.content}
     Should Be Equal As Strings    ${response.status_code}    204
 
@@ -118,7 +118,7 @@ Update Bucket from Public -> to Restricted
     ${body}=    Set Bucket File Allowed Users   ${body}     ${USER}
     ${body}= 	Convert JSON To String 	${body}
     ${response}=    PUT    url=${OSCAR_ENDPOINT}/system/buckets    expected_status=204    data=${body}
-    ...    headers=${HEADERS}
+    ...    headers=${HEADERS}    verify=${SSL_VERIFY}
     Log    ${response.content}
     Should Be Equal As Strings    ${response.status_code}    204
 
@@ -134,7 +134,7 @@ Update Bucket from Restricted -> to Private
     [Tags]    update    bucket
     ${body}=    Get File    ${DATA_DIR}/bucket.json
     ${response}=    PUT    url=${OSCAR_ENDPOINT}/system/buckets    expected_status=204    data=${body}
-    ...    headers=${HEADERS}
+    ...    headers=${HEADERS}    verify=${SSL_VERIFY}
     Log    ${response.content}
     Should Be Equal As Strings    ${response.status_code}    204
 
@@ -148,7 +148,7 @@ Delete Bucket Private
     [Documentation]    Delete a private bucket
     [Tags]    Delete    bucket
     ${response}=    DELETE    url=${OSCAR_ENDPOINT}/system/buckets/${bucket_name}    expected_status=204   
-    ...    headers=${HEADERS}
+    ...    headers=${HEADERS}    verify=${SSL_VERIFY}
     Log    ${response.content}
     Should Be Equal As Strings    ${response.status_code}    204
 
@@ -168,7 +168,7 @@ Create Bucket Restricted
     ${body}=    Set Bucket File Allowed Users   ${body}     ${USER}
     ${body}= 	Convert JSON To String 	${body}
     ${response}=    POST    url=${OSCAR_ENDPOINT}/system/buckets    expected_status=201    data=${body}
-    ...    headers=${HEADERS}
+    ...    headers=${HEADERS}    verify=${SSL_VERIFY}
     Log    ${response.content}
     Should Be Equal As Strings    ${response.status_code}    201
 
@@ -183,7 +183,7 @@ Delete Bucket Restricted
     [Documentation]    Delete a restricted bucket
     [Tags]    Delete    bucket
     ${response}=    DELETE    url=${OSCAR_ENDPOINT}/system/buckets/${bucket_name}    expected_status=204   
-    ...    headers=${HEADERS}
+    ...    headers=${HEADERS}    verify=${SSL_VERIFY}
     Log    ${response.content}
     Should Be Equal As Strings    ${response.status_code}    204
 
@@ -202,7 +202,7 @@ Create Bucket Public
     ${body}=    Set Bucket File Visibility      ${body}     public
     ${body}= 	Convert JSON To String 	${body}
     ${response}=    POST    url=${OSCAR_ENDPOINT}/system/buckets    expected_status=201    data=${body}
-    ...    headers=${HEADERS}
+    ...    headers=${HEADERS}    verify=${SSL_VERIFY}
     Log    ${response.content}
     Should Be Equal As Strings    ${response.status_code}    201
 
@@ -216,7 +216,7 @@ Delete Bucket Public
     [Documentation]    Delete a public bucket
     [Tags]    Delete    bucket
     ${response}=    DELETE    url=${OSCAR_ENDPOINT}/system/buckets/${bucket_name}    expected_status=204   
-    ...    headers=${HEADERS}
+    ...    headers=${HEADERS}    verify=${SSL_VERIFY}
     Log    ${response.content}
     Should Be Equal As Strings    ${response.status_code}    204
 
@@ -231,7 +231,7 @@ Verify Bucket Public Delete
 *** Keywords ***
 Cleanup Bucket Resources
     [Documentation]    Best-effort cleanup of the bucket created by this suite.
-    Run Keyword And Ignore Error    DELETE    url=${OSCAR_ENDPOINT}/system/buckets/${bucket_name}    expected_status=ANY    headers=${HEADERS}
+    Run Keyword And Ignore Error    DELETE    url=${OSCAR_ENDPOINT}/system/buckets/${bucket_name}    expected_status=ANY    headers=${HEADERS}    verify=${SSL_VERIFY}
 
 Get Key From Dictionary
     [Documentation]  Get the key from a dictionary


### PR DESCRIPTION
## Summary

- honor the configured TLS verification setting in direct bucket API requests
- apply the same TLS setting to shared bucket-list verification and cleanup
- generate an isolated bucket name for each presigned URL suite run
- inject the generated name into the bucket creation payload

## Validation

- `tests/api/buckets.robot`: 25 passed, 0 failed
- `tests/api/bucket-presign.robot`: 5 passed, 0 failed
- local OSCAR cluster remained ready after execution
- no buckets, objects, or jobs remained after teardown
- Also tested with the sandbox OSCAR cluster.
