### PR TITLE
Populate OIDC session data in dashboard tests

### DIFF
--- a/resources/dashboard.resource
+++ b/resources/dashboard.resource
@@ -41,8 +41,9 @@ Authenticate To Dashboard
     [Documentation]    Injects the OIDC token in local storage and waits for services to load.
     Provide Endpoint If Prompted
     ${token}=    Get Access Token
+    ${egi_session}=    Decode JWT Token    ${token}
     ${auth_data_json}=    Evaluate
-    ...    json.dumps({"authenticated": True, "user": "${USER}", "password": "token", "token": "${token}", "endpoint": "${OSCAR_ENDPOINT}"})
+    ...    json.dumps({"authenticated": True, "user": "${USER}", "password": "token", "token": "${token}", "endpoint": "${OSCAR_ENDPOINT}", "egiSession": $egi_session})
     ...    json
     LocalStorage Set Item    authData    ${auth_data_json}
     Reload


### PR DESCRIPTION
## Summary

- decode the Keycloak access token used by dashboard tests
- store the decoded claims as `egiSession` in the injected authentication data
- preserve the original token for backend requests

## Root cause

Dashboard tests injected a token into local storage without the decoded OIDC session data produced by the normal login flow. Components that inspect user VO or Keycloak role claims therefore received an incomplete authentication object.

## Impact

Dashboard UI tests now reproduce the authentication structure used by real OIDC sessions, including role and group claims required by integrated application forms such as Notebooks.

## Validation

- Robot Framework dry run of `tests/dashboard/notebooks.robot`: 3 tests passed
- `git diff --check`

The live cluster test was intentionally left for manual verification.