### PR TITLE
Guard metrics population resource usage

### DIFF
--- a/tests/populate/README.md
+++ b/tests/populate/README.md
@@ -25,6 +25,10 @@ variables/.env-auth-keycloak-oscarusers.yaml
 
 You also need to pass the target cluster variables file, as with the rest of the OSCAR tests.
 
+Before creating services, the suite checks `/system/quotas/user` for both users
+and fails during setup if either user lacks the MinIO bucket slots required for
+the complete batch. Delete-only runs skip this check.
+
 ## Populate and Leave Services Running
 
 This is the default mode. It creates four `cowsay` services, one exposed nginx service, and one shared service. Each numbered `cowsay` service is invoked twice synchronously and twice asynchronously. The exposed service is invoked twice through `/system/services/{service}/exposed`. The shared service is invoked once synchronously and once asynchronously by each user. Services are left in the cluster.

--- a/tests/populate/populate-metrics.robot
+++ b/tests/populate/populate-metrics.robot
@@ -27,10 +27,10 @@ ${POPULATE_SHARED_SYNC_INVOCATIONS}     1
 ${POPULATE_SHARED_ASYNC_INVOCATIONS}    1
 ${POPULATE_CLEANUP}                 ${False}
 ${POPULATE_DELETE_ONLY}             ${False}
-${POPULATE_SERVICE_CPU}             0.5
-${POPULATE_SERVICE_MEMORY}          256Mi
-${POPULATE_EXPOSED_CPU}             0.5
-${POPULATE_EXPOSED_MEMORY}          256Mi
+${POPULATE_SERVICE_CPU}             0.1
+${POPULATE_SERVICE_MEMORY}          128Mi
+${POPULATE_EXPOSED_CPU}             0.1
+${POPULATE_EXPOSED_MEMORY}          128Mi
 ${POPULATE_SERVICE_FILE}            ${DATA_DIR}/00-cowsay.yaml
 ${POPULATE_SERVICE_SCRIPT}          ${DATA_DIR}/00-cowsay-script.sh
 ${POPULATE_EXPOSED_SERVICE_FILE}    ${DATA_DIR}/expose_services/nginx_expose.yaml
@@ -206,6 +206,35 @@ Setup Populate Metrics Suite
     Log To Console    OSCAR populate exposed service: ${POPULATE_EXPOSED_PREFIX}-${POPULATE_RUN_ID}
     Log To Console    OSCAR populate shared service: ${POPULATE_SHARED_PREFIX}-${POPULATE_RUN_ID}
     Variable Should Exist    ${HEADERS2}    This suite needs a secondary user. Use variables/.env-auth-keycloak-oscarusers.yaml or another auth file that defines KEYCLOAK_USERNAME_AUX.
+    IF    not ${POPULATE_DELETE_ONLY}
+        Check Populate MinIO Bucket Quotas
+    END
+
+Check Populate MinIO Bucket Quotas
+    [Documentation]    Fail before service creation unless both users have enough free MinIO bucket slots.
+    ${primary_required}=    Evaluate    (int($POPULATE_SERVICE_COUNT) + 1) // 2 + 1
+    ${secondary_required}=    Evaluate    int($POPULATE_SERVICE_COUNT) // 2 + 1
+    Check Populate User MinIO Bucket Quota    primary user    ${HEADERS}    ${primary_required}
+    Check Populate User MinIO Bucket Quota    secondary user    ${HEADERS2}    ${secondary_required}
+
+Check Populate User MinIO Bucket Quota
+    [Documentation]    Verify that one user's quota can accommodate all buckets assigned by this suite.
+    [Arguments]    ${user_label}    ${headers}    ${required_buckets}
+    ${response}=    GET With Defaults    url=${OSCAR_ENDPOINT}/system/quotas/user    expected_status=ANY    headers=${headers}
+    Should Be Equal As Strings
+    ...    ${response.status_code}
+    ...    200
+    ...    msg=Unable to verify MinIO bucket quota for ${user_label}: GET /system/quotas/user returned ${response.status_code}: ${response.content}
+    ${payload}=    Evaluate    json.loads($response.content)    json
+    Dictionary Should Contain Key    ${payload}    minio
+    ${buckets}=    Get From Dictionary    ${payload}[minio]    buckets
+    ${max_buckets}=    Get From Dictionary    ${buckets}    max
+    ${used_buckets}=    Get From Dictionary    ${buckets}    used
+    ${available_buckets}=    Evaluate    int($max_buckets) - int($used_buckets)
+    Log To Console    OSCAR populate bucket quota for ${user_label}: max=${max_buckets}, used=${used_buckets}, available=${available_buckets}, required=${required_buckets}
+    Should Be True
+    ...    ${available_buckets} >= ${required_buckets}
+    ...    msg=Not enough MinIO bucket quota for ${user_label}: available=${available_buckets}, required=${required_buckets}, max=${max_buckets}, used=${used_buckets}. Delete unused services or buckets, or increase the user's quota.
 
 Teardown Populate Metrics Suite
     [Documentation]    Optionally remove services and always remove generated service JSON files.


### PR DESCRIPTION
## Summary

- check MinIO bucket availability for both Keycloak users before the population suite creates any services
- calculate the number of bucket slots required by each user from the configured service count and ownership split
- fail during suite setup with an actionable quota message instead of leaving a partially created batch
- reduce the default CPU and memory requests for generated services from `0.5 CPU / 256Mi` to `0.1 CPU / 128Mi`
- document the quota preflight and its delete-only behavior

## Problem

The metrics population suite creates four regular services, one exposed service, and one shared service across two users. Repeated runs on a quota-enabled cluster could fail partway through service creation.

Two resource constraints were observed:

1. A user at the MinIO bucket limit received HTTP 403 while creating the first service assigned to that user. Since the suite checked quota only indirectly through service creation, earlier services could already have been created, leaving a partial batch and causing later readiness tests to wait for resources that would never exist.
2. The original `0.5 CPU / 256Mi` requests generated significant transient Kueue pressure while Knative revisions and the exposed deployment were created close together. On a per-user CPU quota of two cores, the exposed workload could remain pending when other revision workloads temporarily held reservations.

## Root cause

The suite assumed a sufficiently empty cluster and did not validate bucket capacity before starting. It also used resource requests that were larger than necessary for the lightweight cowsay and nginx workloads used only to populate metrics.

Because service names and buckets are split between two users, checking only one account would not prevent partial creation. Each user's quota must be evaluated independently using that user's bearer token.

## Changes

The suite setup now calls `/system/quotas/user` for both users and validates the available MinIO bucket slots before any service is created.

For the default four-service configuration:

- the primary user needs three bucket slots: two regular services and the shared service
- the secondary user needs three bucket slots: two regular services and the exposed service

The calculation follows `POPULATE_SERVICE_COUNT`, so custom service counts retain the correct even/odd ownership distribution. Delete-only executions skip the preflight so previous batches can still be removed when quota is exhausted.

Default resource requests for both regular and exposed services are reduced to:

```
CPU:    0.1
Memory: 128Mi
```

These values are sufficient for the test workloads and reduce unnecessary Kueue contention.

## Impact

Quota failures are reported immediately during suite setup with maximum, used, available, and required bucket counts. The suite no longer starts a batch when it cannot complete service creation for both users.

Lower resource requests make the population workflow more reliable on quota-constrained clusters while preserving its purpose: creating services and generating synchronous, asynchronous, exposed, and shared-service metrics.

## Validation

- `git diff --check`
- Robot Framework dry run for the create-tagged population test
- complete execution against the local OSCAR cluster:
  - 7 tests
  - 6 passed
  - 0 failed
  - 1 skipped
